### PR TITLE
Ginso escape reset and bug fixes

### DIFF
--- a/Core/LocalGameState.cs
+++ b/Core/LocalGameState.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OriBFArchipelago.Core
+{
+    // Maintain game states that doesn't need to be saved
+    internal class LocalGameState
+    {
+        public static bool IsGinsoExit = false;
+
+        public static void Reset()
+        {
+            IsGinsoExit = false;
+        }
+    }
+}

--- a/Core/LocalGameState.cs
+++ b/Core/LocalGameState.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Reflection;
 
 namespace OriBFArchipelago.Core
 {
@@ -9,10 +10,20 @@ namespace OriBFArchipelago.Core
     internal class LocalGameState
     {
         public static bool IsGinsoExit = false;
-
+        public static bool IsPendingCheckpoint = false;
+        public static bool IsTeleporting { 
+            get
+            {
+                Type teleporterType = typeof(TeleporterController);
+                FieldInfo isTeleportingField = teleporterType.GetField("m_isTeleporting", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                var value = isTeleportingField.GetValue(TeleporterController.Instance);
+                return (bool)value;
+            }
+        }
         public static void Reset()
         {
             IsGinsoExit = false;
+            IsPendingCheckpoint = false;
         }
     }
 }

--- a/Core/RandomizerBootstrap.cs
+++ b/Core/RandomizerBootstrap.cs
@@ -133,6 +133,10 @@ namespace OriBFArchipelago.Core
                 AddActivator(artAfter, artAfter.Find("heartClean").gameObject, condition);
                 AddActivator(artAfter, artAfter.Find("rotatingLightraysA").gameObject, condition);
                 AddActivator(artAfter, artAfter.Find("rotatingLightraysB").gameObject, condition);
+
+                // Make it so we can retrigger the escape sequence
+                var interestTrigger = sceneRoot.transform.Find("*heartResurrection/restoringHeartWaterRising/triggerWaterSequence").GetComponent<OriInterestTriggerB>();
+                interestTrigger.RunOnce = false;
             }
 
             {
@@ -155,8 +159,7 @@ namespace OriBFArchipelago.Core
 
         private static void BootstrapKuroMomentCutscene(SceneRoot sceneRoot)
         {
-            var action = InsertAction<SendLocalAPItemsAction>(sceneRoot.transform.Find("masterTimelineSequence/actionSequence").GetComponent<ActionSequence>(), 0, new MoonGuid(307071171, -850108097, -1715582487, 2063130120), sceneRoot);
-            action.Item = InventoryItem.GinsoEscapeExit;
+            var action = InsertAction<SetGinsoExitAction>(sceneRoot.transform.Find("masterTimelineSequence/actionSequence").GetComponent<ActionSequence>(), 0, new MoonGuid(307071171, -850108097, -1715582487, 2063130120), sceneRoot);
         }
 
         private static void AddActivator(Transform root, GameObject target, Condition condition)
@@ -236,7 +239,7 @@ namespace OriBFArchipelago.Core
 
         public override bool Validate(IContext context)
         {
-            return ((RandomizerManager.Receiver?.HasItem(InventoryItem.GinsoEscapeExit) ?? false) || (RandomizerManager.Receiver?.HasItem(InventoryItem.GinsoEscapeComplete) ?? false)) == IsTrue;
+            return (LocalGameState.IsGinsoExit || (RandomizerManager.Receiver?.HasItem(InventoryItem.GinsoEscapeComplete) ?? false)) == IsTrue;
         }
     }
 
@@ -270,13 +273,21 @@ namespace OriBFArchipelago.Core
         }
     }
 
+    internal class SetGinsoExitAction : ActionMethod
+    {
+        public override void Perform(IContext context)
+        {
+            LocalGameState.IsGinsoExit = true;
+        }
+    }
+
     public class LeftGinsoCondition : Condition
     {
         public bool IsTrue = true;
 
         public override bool Validate(IContext context)
         {
-            return RandomizerManager.Receiver.HasItem(InventoryItem.GinsoEscapeExit) == IsTrue;
+            return LocalGameState.IsGinsoExit == IsTrue;
         }
     }
 }

--- a/Core/RandomizerInventory.cs
+++ b/Core/RandomizerInventory.cs
@@ -84,6 +84,9 @@ namespace OriBFArchipelago.Core
         EX100,
         EX200,
         EnemyEX,
+
+        GinsoEscapeExit,
+        GinsoEscapeComplete,
     }
 
     /**

--- a/Core/RandomizerInventory.cs
+++ b/Core/RandomizerInventory.cs
@@ -85,7 +85,6 @@ namespace OriBFArchipelago.Core
         EX200,
         EnemyEX,
 
-        GinsoEscapeExit,
         GinsoEscapeComplete,
     }
 

--- a/Core/RandomizerManager.cs
+++ b/Core/RandomizerManager.cs
@@ -202,6 +202,7 @@ namespace OriBFArchipelago.Core
             connection = null;
             receiver.OnSave();
             receiver = null;
+            LocalGameState.Reset();
         }
 
         /**

--- a/Core/RandomizerReceiver.cs
+++ b/Core/RandomizerReceiver.cs
@@ -27,9 +27,6 @@ namespace OriBFArchipelago.Core
         // compares against savedInventory to make sure items aren't duplicated
         private RandomizerInventory onLoadInventory;
 
-        // inventory for temporary items whice are never saved
-        private RandomizerInventory tempInventory;
-
         // the number of the associated save slot in Ori
         private int saveSlot;
 
@@ -42,9 +39,6 @@ namespace OriBFArchipelago.Core
         public bool IsSuspended { get; set; }
 
         private List<InventoryItem> localInventoryItems = new List<InventoryItem> { InventoryItem.AbilityCellUsed, InventoryItem.KeyStoneUsed, InventoryItem.MapStoneUsed, InventoryItem.EnemyEX, InventoryItem.GladesKeyStoneUsed, InventoryItem.GrottoKeyStoneUsed, InventoryItem.GinsoKeyStoneUsed, InventoryItem.SwampKeyStoneUsed, InventoryItem.MistyKeyStoneUsed, InventoryItem.ForlornKeyStoneUsed, InventoryItem.SorrowKeyStoneUsed, InventoryItem.GladesMapStoneUsed, InventoryItem.GroveMapStoneUsed, InventoryItem.GrottoMapStoneUsed, InventoryItem.SwampMapStoneUsed, InventoryItem.ValleyMapStoneUsed, InventoryItem.ForlornMapStoneUsed, InventoryItem.SorrowMapStoneUsed, InventoryItem.HoruMapStoneUsed, InventoryItem.BlackrootMapStoneUsed, InventoryItem.GinsoEscapeComplete };
-
-        // These items will not be saved unless staged
-        private List<InventoryItem> tempInventoryItems = new List<InventoryItem> { InventoryItem.GinsoEscapeExit };
 
         private int keystoneCount = 0;
         private int mapstoneCount = 0;
@@ -64,7 +58,6 @@ namespace OriBFArchipelago.Core
 
             onLoadInventory = new RandomizerInventory(VERSION, apSlotName);
             unsavedInventory = new RandomizerInventory(VERSION, apSlotName);
-            tempInventory = new RandomizerInventory(VERSION, apSlotName);
 
             if (isNew)
             {
@@ -195,10 +188,6 @@ namespace OriBFArchipelago.Core
             if (localInventoryItems.Contains(item))
             {
                 unsavedInventory.Add(item, count);
-            }
-            else if (tempInventoryItems.Contains(item))
-            {
-                tempInventory.Add(item, count);
             }
             else if (onLoadInventory.CompareOn(savedInventory, item) < 0)
             {
@@ -497,7 +486,7 @@ namespace OriBFArchipelago.Core
 
         public int GetItemCount(InventoryItem item)
         {
-            return savedInventory.Get(item) + unsavedInventory.Get(item) + tempInventory.Get(item);
+            return savedInventory.Get(item) + unsavedInventory.Get(item);
         }
 
         public bool HasItem(InventoryItem item)

--- a/Core/WorldEventsHelper.cs
+++ b/Core/WorldEventsHelper.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OriBFArchipelago.Core
+{
+    internal class WorldEventsHelper
+    {
+        public static Dictionary<MoonGuid, WorldEventsRuntime> GameEventsRuntime = null;
+
+        public static WorldEventsRuntime GinsoWorldEvents
+        {
+            get
+            {
+                if (GameEventsRuntime != null && GameEventsRuntime.TryGetValue(ginsoEventsGuid, out WorldEventsRuntime ginsoEventsRuntime))
+                {
+                    return ginsoEventsRuntime;
+                }
+                return null;
+            }
+        }
+
+        public static WorldEventsRuntime MistyWorldEvents
+        {
+            get
+            {
+                if (GameEventsRuntime != null && GameEventsRuntime.TryGetValue(mistyEventsGuid, out WorldEventsRuntime mistyEventsRuntime))
+                {
+                    return mistyEventsRuntime;
+                }
+                return null;
+            }
+        }
+
+        private static MoonGuid ginsoEventsGuid = new MoonGuid(687998245, 1199897005, -1787166542, 576748618);
+        private static MoonGuid mistyEventsGuid = new MoonGuid(1061758509, 1206015992, 824243626, -2026069462);
+
+    }
+}

--- a/Patches/GinsoSideRoomPatch.cs
+++ b/Patches/GinsoSideRoomPatch.cs
@@ -15,7 +15,7 @@ namespace OriBFArchipelago.Patches
         {
             // I'll be honest I don't know how but this fixes a bug at the side rooms next to the ginso core
             //  where the areas don't load if you finish the escape, come back and don't have clean water
-            if (__instance.WorldEvents.UniqueID == 26 && RandomizerManager.Connection.IsGinsoEscapeComplete())
+            if (__instance.WorldEvents.UniqueID == 26 && (RandomizerManager.Receiver?.HasItem(InventoryItem.GinsoEscapeComplete) ?? false))
             {
                 __result = __instance.State != 21;
                 return false;

--- a/Patches/RuntimeSceneMetaDataPatches.cs
+++ b/Patches/RuntimeSceneMetaDataPatches.cs
@@ -1,0 +1,29 @@
+﻿using HarmonyLib;
+using OriBFArchipelago.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace OriBFArchipelago.Patches
+{
+    [HarmonyPatch(typeof(RuntimeSceneMetaData), nameof(RuntimeSceneMetaData.IsInsideScenePaddingBounds), new Type[] { typeof(Rect) })]
+    internal class RuntimeSceneMetaDataPatches
+    {
+        private static bool Prefix(RuntimeSceneMetaData __instance, ref bool __result)
+        {
+            // We would like to keep these scenes loaded for clean up.
+            if (__instance.Scene == "ginsoTreeResurrection" || __instance.Scene == "ginsoTreeWaterRisingEnd")
+            {
+                int ginsoEventsValue = WorldEventsHelper.GinsoWorldEvents?.Value ?? 23;
+                if ((ginsoEventsValue == 25 || ginsoEventsValue == 21) && !LocalGameState.IsGinsoExit && !(RandomizerManager.Receiver?.HasItem(InventoryItem.GinsoEscapeComplete) ?? true))
+                {
+                    __result = true;
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/Patches/ScenesManagerPatches.cs
+++ b/Patches/ScenesManagerPatches.cs
@@ -1,0 +1,44 @@
+﻿using Core;
+using HarmonyLib;
+using OriBFArchipelago.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OriBFArchipelago.Patches
+{
+    [HarmonyPatch(typeof(ScenesManager), nameof(ScenesManager.Awake))]
+    internal class ScenesManagerPatches
+    {
+        private static void PatchKuroMomentTreeFallCutsceneDuplicate(RuntimeSceneMetaData sceneMetaData)
+        {
+            CompoundCondition compCondition = (CompoundCondition) sceneMetaData.LoadingCondition;
+
+            NotCondition previousCondition = (NotCondition) compCondition.Tests[0].Conditions[1];
+
+            var innerCondition = previousCondition.Condition;
+
+            compCondition.Tests[0].Conditions[1] = new IsInGinsoKuroCutsceneCondition();
+            UnityEngine.Object.Destroy(innerCondition);
+            UnityEngine.Object.Destroy(previousCondition);
+        }
+
+        private static void Postfix()
+        {
+            MoonGuid guid = new MoonGuid(-172843866, 436504499, -1307662934, 1026713766);
+            RuntimeSceneMetaData kuroMomentTreeFallCutsceneDuplicateMetaData = Scenes.Manager.FindRuntimeSceneMetaData(guid);
+            PatchKuroMomentTreeFallCutsceneDuplicate(kuroMomentTreeFallCutsceneDuplicateMetaData);
+        }
+    }
+
+    public class IsInGinsoKuroCutsceneCondition : Condition
+    {
+        public bool IsTrue = true;
+
+        public override bool Validate(IContext context)
+        {
+            return ((RandomizerManager.Receiver?.HasItem(InventoryItem.GinsoEscapeExit) ?? false) && !(RandomizerManager.Receiver?.HasItem(InventoryItem.GinsoEscapeComplete) ?? false)) == IsTrue;
+        }
+    }
+}

--- a/Patches/ScenesManagerPatches.cs
+++ b/Patches/ScenesManagerPatches.cs
@@ -38,7 +38,7 @@ namespace OriBFArchipelago.Patches
 
         public override bool Validate(IContext context)
         {
-            return ((RandomizerManager.Receiver?.HasItem(InventoryItem.GinsoEscapeExit) ?? false) && !(RandomizerManager.Receiver?.HasItem(InventoryItem.GinsoEscapeComplete) ?? false)) == IsTrue;
+            return (LocalGameState.IsGinsoExit && !(RandomizerManager.Receiver?.HasItem(InventoryItem.GinsoEscapeComplete) ?? false)) == IsTrue;
         }
     }
 }

--- a/Patches/TeleporterControllerPatch.cs
+++ b/Patches/TeleporterControllerPatch.cs
@@ -1,5 +1,7 @@
 ﻿using Game;
+using Core;
 using HarmonyLib;
+using OriBFArchipelago.Core;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,6 +13,84 @@ namespace OriBFArchipelago.Patches
     [HarmonyPatch(typeof(TeleporterController))]
     internal static class TeleporterControllerPatches
     {
+        [HarmonyPrefix, HarmonyPatch(nameof(TeleporterController.OnFadedToBlack))]
+        private static bool OnFadedToBlackPrefix()
+        {
+
+            // Reset ginso tree
+            var ginsoSim = new WorldEvents();
+            ginsoSim.MoonGuid = new MoonGuid(687998245, 1199897005, -1787166542, 576748618);
+            int ginsoEventsValue = World.Events.Find(ginsoSim).Value;
+            Console.WriteLine(ginsoEventsValue);
+            if (ginsoEventsValue == 21 && !(LocalGameState.IsGinsoExit) && !(RandomizerManager.Receiver?.HasItem(InventoryItem.GinsoEscapeComplete) ?? true))
+            {
+
+                var ginsoTreeResurrectionSceneManagerScene = Scenes.Manager.GetSceneManagerScene("ginsoTreeResurrection");
+                var ginsoTreeResurrectionScene = ginsoTreeResurrectionSceneManagerScene.SceneRoot;
+
+                // Revert the sequence of events when restoring Ginso tree
+
+                ginsoTreeResurrectionScene.transform.Find("musicZones/musicZoneHeartBefore").gameObject.SetActive(true);
+                ginsoTreeResurrectionScene.transform.Find("musicZones").GetChild(1).GetChild(0).GetChild(0).gameObject.SetActive(false);
+                ginsoTreeResurrectionScene.transform.Find("*heartResurrection/restoringHeartWaterRising/activator/group/scrollLockWaterRising").gameObject.SetActive(false);
+                ginsoTreeResurrectionScene.transform.Find("*heartResurrection/restoringHeartWaterRising/purpleGoopFallSounds").gameObject.SetActive(true);
+                ginsoTreeResurrectionScene.transform.Find("*heartResurrection/blockingCreep/blockingCreep").gameObject.SetActive(true);
+                ginsoTreeResurrectionScene.transform.Find("*heartResurrection/restoringHeartWaterRising/triggerWaterSequence").gameObject.SetActive(true);
+                ginsoTreeResurrectionScene.transform.Find("surfaceColliders/surfaceColliderAfterResurrection").gameObject.SetActive(false);
+                ginsoTreeResurrectionScene.transform.Find("*heartResurrection/chainReactionSetup/spiritLanternPlaceholders/middle").GetChild(0).Find("spiritLantern").gameObject.SetActive(false);
+                ginsoTreeResurrectionScene.transform.Find("*heartResurrection/chainReactionSetup/spiritLanternPlaceholders/middle").GetChild(0).Find("lock").gameObject.SetActive(true);
+
+                ginsoTreeResurrectionScene.transform.Find("*heartResurrection/restoringHeartWaterRising/triggerWaterSequence").gameObject.SetActive(true);
+
+                BaseAnimatorAction reverseTimelineSequenceAction = new BaseAnimatorAction();
+                var timelineSequenceObject = ginsoTreeResurrectionScene.transform.Find("*heartResurrection/restoringHeartWaterRising/timelineSequence").gameObject;
+
+                reverseTimelineSequenceAction.Target = timelineSequenceObject;
+                reverseTimelineSequenceAction.Command = BaseAnimatorAction.PlayMode.StopAtStart;
+                reverseTimelineSequenceAction.AnimatorsMode = BaseAnimatorAction.FindAnimatorsMode.GameObject;
+                reverseTimelineSequenceAction.Start();
+                reverseTimelineSequenceAction.Perform(null);
+
+                var ginsoTreeWaterRisingBackgroundSceneManagerScene = Scenes.Manager.GetSceneManagerScene("ginsoTreeWaterRisingBackground");
+                var ginsoTreeWaterRisingBackgroundScene = ginsoTreeWaterRisingBackgroundSceneManagerScene.SceneRoot;
+
+                // Reset water level
+
+                AnimatorAction reverseRisingWaterSequenceAction = new AnimatorAction();
+                var risingWaterGameObject = ginsoTreeWaterRisingBackgroundScene.transform.Find("*risingWaterGroup/*risingWater").gameObject;
+
+                foreach (LegacyTranslateAnimator animator in risingWaterGameObject.GetComponents<LegacyTranslateAnimator>())
+                {
+                    animator.Restart();
+                    animator.StopAndSampleAtStart();
+                    animator.AnimateX = true;
+                    animator.AnimateY = true;
+                    animator.AnimateZ = true;
+                    animator.RestoreToOriginalState();
+                    animator.AnimateX = false;
+                    animator.AnimateY = false;
+                    animator.AnimateZ = false;
+                }
+
+                ginsoTreeWaterRisingBackgroundScene.transform.Find("particles").gameObject.SetActive(false);
+
+                var blockingWallsAnimator = ginsoTreeResurrectionScene.transform.Find("*heartResurrection/restoringHeartWaterRising/blockingWalls").GetComponentsInChildren<LegacyAnimator>();
+
+                foreach (LegacyAnimator animator in blockingWallsAnimator)
+                {
+                    animator.Restart();
+                    animator.StopAndSampleAtStart();
+                }
+
+                World.Events.Find(ginsoSim).Value = 23;
+
+                // Unloaing scenes seems to cleared up random debris on second trigger after TP
+                // OriCore.Scenes.Manager.UnloadScene(ginsoTreeResurrectionSceneManagerScene, false, true);
+                Scenes.Manager.UnloadAllScenes();
+            }
+            return true;
+        }
+
         [HarmonyPostfix, HarmonyPatch(nameof(TeleporterController.OnFadedToBlack))]
         private static void OnFadedToBlackPostfix()
         {

--- a/Patches/WorldEventsManagerPatches.cs
+++ b/Patches/WorldEventsManagerPatches.cs
@@ -1,0 +1,23 @@
+﻿using HarmonyLib;
+using OriBFArchipelago.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OriBFArchipelago.Patches
+{
+
+    [HarmonyPatch(typeof(WorldEventsManager), nameof(WorldEventsManager.Find))]
+    internal class WorldEventsManagerPatches
+    {
+        private static bool Prefix(ref Dictionary<MoonGuid, WorldEventsRuntime> ___m_worldEvents)
+        {
+            if (WorldEventsHelper.GameEventsRuntime == null)
+            {
+                WorldEventsHelper.GameEventsRuntime = ___m_worldEvents;
+            }
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Feature:
- Reset Ginso escape sequence on teleporting out.
Bugfixes:
- Fixed an issue where returning to title screen during prologue makes Ori falls into the void.
- Fixed a similar issue when returning to title screen at Ginso heart.
- Mitigated similar potential issues for Misty wood.
- Fixed Ginso Kuro cutscene where game pauses when progressing through the cutscene without stomp.
- Fixed cutscene glitch when trying to teleport out at the top just before exit.