### PR TITLE
Better keybinds

### DIFF
--- a/Core/Keybinder.cs
+++ b/Core/Keybinder.cs
@@ -27,7 +27,9 @@ namespace OriBFArchipelago.Core
     {
         OpenTeleport,
         DoubleBash,
-        GrenadeJump
+        GrenadeJump,
+        ListStones,
+        GoalProgress
     }
 
     /**
@@ -60,13 +62,15 @@ namespace OriBFArchipelago.Core
         };
 
         /**
-         * Default keybinds for the above actions
+         * Default keybinds for the KeybindActions
          */ 
         private static Dictionary<KeybindAction, string> defaultKeybinds = new Dictionary<KeybindAction, string>
         {
             { KeybindAction.OpenTeleport, "LeftAlt+T, RightAlt+T" },
             { KeybindAction.DoubleBash, "Grenade" },
-            { KeybindAction.GrenadeJump, "Grenade+Jump" }
+            { KeybindAction.GrenadeJump, "Grenade+Jump" },
+            { KeybindAction.ListStones, "LeftAlt+S, RightAlt+S" },
+            { KeybindAction.GoalProgress, "LeftAlt+G, RightAlt+G" }
         };
 
         /**

--- a/Core/Keybinder.cs
+++ b/Core/Keybinder.cs
@@ -1,0 +1,387 @@
+﻿using Core;
+using OriModding.BF.InputLib;
+using SmartInput;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+using Input = Core.Input;
+
+namespace OriBFArchipelago.Core
+{
+    /**
+     * Links custom randomizer actions to keybinds
+     */
+    internal class Keybinder : MonoBehaviour
+    {
+        /**
+         * Map core input names to their corresponding name in the Input enum
+         * (Mostly the same except for Dash and Grenade)
+         */
+        private static Dictionary<string, Input.InputButtonProcessor> coreInputMap = new Dictionary<string, Input.InputButtonProcessor>
+        {
+            {"Jump", Input.Jump},
+            {"SpiritFlame", Input.SpiritFlame},
+            {"Bash", Input.Bash},
+            {"SoulFlame", Input.SoulFlame},
+            {"ChargeJump", Input.ChargeJump},
+            {"Glide", Input.Glide},
+            {"Dash", Input.RightShoulder},
+            {"Grenade", Input.LeftShoulder},
+            {"Left", Input.Left},
+            {"Right", Input.Right},
+            {"Up", Input.Up},
+            {"Down", Input.Down},
+            {"LeftStick", Input.LeftStick},
+            {"RightStick", Input.RightStick},
+            {"Start", Input.Start},
+            {"Select", Input.Select}
+        };
+
+        /**
+         * Define the custom randomizer actions
+         */
+        internal enum Action
+        {
+            OpenTeleport,
+            DoubleBash,
+            GrenadeJump
+        }
+
+        /**
+         * Default keybinds for the above actions
+         */ 
+        private static Dictionary<Action, string> defaultKeybinds = new Dictionary<Action, string>
+        {
+            { Action.OpenTeleport, "LeftAlt+T, RightAlt+T" },
+            { Action.DoubleBash, "Grenade" },
+            { Action.GrenadeJump, "Grenade+Jump" }
+        };
+
+        /**
+         * Used with dictionary below for mapping controller button names to XboxControllerInput
+         */
+        internal enum ControllerButton
+        {
+            A,
+            B,
+            X,
+            Y,
+            LT,
+            RT,
+            LB,
+            RB,
+            LS,
+            RS
+        }
+
+        /**
+         * Used with enum above for mapping controller button names to XboxControllerInput
+         */
+        private static Dictionary<ControllerButton, XboxControllerInput.Button> controllerMap = new Dictionary<ControllerButton, XboxControllerInput.Button>
+        {
+            { ControllerButton.A, XboxControllerInput.Button.ButtonA },
+            { ControllerButton.B, XboxControllerInput.Button.ButtonB },
+            { ControllerButton.X, XboxControllerInput.Button.ButtonX },
+            { ControllerButton.Y, XboxControllerInput.Button.ButtonY },
+            { ControllerButton.LT, XboxControllerInput.Button.LeftTrigger },
+            { ControllerButton.RT, XboxControllerInput.Button.RightTrigger },
+            { ControllerButton.LB, XboxControllerInput.Button.LeftShoulder },
+            { ControllerButton.RB, XboxControllerInput.Button.RightShoulder },
+            { ControllerButton.LS, XboxControllerInput.Button.LeftStick },
+            { ControllerButton.RS, XboxControllerInput.Button.RightStick }
+        };
+
+        /**
+         * Represents a single key or button press
+         */
+        public class SingleInput: Input.InputButtonProcessor
+        {
+            public enum InputType
+            {
+                CoreInput,
+                ControllerButton,
+                KeyCode
+            };
+
+            private string raw;
+
+            private KeyCode key;
+
+            private Input.InputButtonProcessor coreInput;
+
+            private ControllerButton button;
+
+            private InputType type;
+
+            public SingleInput(string input)
+            {
+                input = input.Trim();
+
+                raw = input;
+                if (input.StartsWith("_"))
+                {
+                    type = InputType.ControllerButton;
+                    button = (ControllerButton)Enum.Parse(typeof(ControllerButton), input.Substring(1), true);
+                }
+                else if (coreInputMap.ContainsKey(input))
+                {
+                    type = InputType.CoreInput;
+                    coreInput = coreInputMap[input];
+                }
+                else
+                {
+                    type = InputType.KeyCode;
+                    key = input != "" ? (KeyCode)Enum.Parse(typeof(KeyCode), input, true) : KeyCode.None;
+                }
+            }
+
+            public override string ToString()
+            {
+                return raw;
+            }
+
+            /**
+             * Intended to be called every frame to update the state of this input
+             */
+            public void UpdateState()
+            {
+                switch (type)
+                {
+                    case InputType.CoreInput:
+                        this.Update(coreInput.Pressed);
+                        break;
+                    case InputType.ControllerButton:
+                        this.Update(new ControllerButtonInput(controllerMap[button]).GetButton());
+                        break;
+                    case InputType.KeyCode:
+                        this.Update(MoonInput.GetKey(key));
+                        break;
+                }
+            }
+        }
+
+        /**
+         * Represents a chord of keys (could still be one key)
+         */
+        private class SingleBind
+        {
+            List<SingleInput> inputs = new List<SingleInput>();
+            SingleInput activator; // used for determining when OnPressed event triggers; always last key named in sequence
+
+            public SingleBind(string data)
+            {
+                string[] inputStrings = data.Trim().Split('+');
+
+                foreach (string inputString in inputStrings)
+                {
+                    try
+                    {
+                        inputs.Add(new SingleInput(inputString));
+                    }
+                    catch (ArgumentException)
+                    { 
+                        // Log the specific failing key, but then pass on the exception since this single bind isn't complete
+                        Console.WriteLine("Keybinder: Unrecognized key \"" + inputString + "\" found in file");
+                        inputs.Clear();
+                        throw new ArgumentException();
+                    }
+                }
+
+                activator = inputs.Last();
+            }
+
+            public SingleBind(List<SingleInput> inputs)
+            {
+                this.inputs = inputs;
+                activator = inputs.Last();
+            }
+
+            /**
+             * Intended to be called every frame to update the state of this keybind
+             */
+            public void UpdateState()
+            {
+                foreach (SingleInput input in inputs)
+                {
+                    input.UpdateState();
+                }
+            }
+
+            public override string ToString()
+            {
+                return string.Join("+", inputs.Select(i => i.ToString()).ToArray());
+            }
+
+            /**
+             * Returns true while all inputs are pressed down
+             */
+            public bool IsPressed
+            {
+                get
+                {
+                    return inputs.All(i => i.IsPressed);
+                }
+            }
+
+            /**
+             * Is true only the moment the full keybind is pressed down
+             * Expects there to be an activator key that is pressed last
+             */
+            public bool OnPressed
+            {
+                get
+                {
+                    return inputs.Where(i => i != activator).All(j => j.IsPressed) && activator.OnPressed;
+                }
+            }
+        }
+
+        /**
+         * Represents a set of keybinds that are all linked to the same action
+         */
+        private class BindSet
+        {
+            List<SingleBind> binds = new List<SingleBind>();
+
+            public BindSet(string data)
+            {
+                string[] bindStrings = data.Trim().Split(',');
+
+                foreach (string bindString in bindStrings)
+                {
+                    try
+                    {
+                        binds.Add(new SingleBind(bindString));
+                    }
+                    catch (ArgumentException)
+                    {
+                        // Can safely log error and move on to the next keybind
+                        Console.WriteLine("Keybinder: Unable to parse keybind \"" + bindString.Trim() + "\"");
+                    }
+                }
+            }
+
+            public BindSet(List<SingleBind> binds)
+            {
+                this.binds = binds;
+            }
+
+            /**
+             * Intended to be called every frame to update the state of each keybind
+             */
+            public void UpdateState()
+            {
+                foreach (SingleBind bind in binds)
+                {
+                    bind.UpdateState();
+                }
+            }
+
+            public override string ToString()
+            {
+                return string.Join(", ", binds.Select(i => i.ToString()).ToArray());
+            }
+
+            /**
+             * Returns true if any of the binds are pressed
+             */
+            public bool IsPressed
+            {
+                get
+                {
+                    return binds.Any(i => i.IsPressed);
+                }
+            }
+
+            /**
+             * Returns true when one of the binds OnPressed fires
+             */
+            public bool OnPressed
+            {
+                get
+                {
+                    return binds.Any(i => i.OnPressed);
+                }
+            }
+        }
+
+        /**
+         * Creates a dictionary of bindsets using a provided dictionary of keybind strings
+         * If any actions are not set, they are filled with the defaults
+         */
+        private static Dictionary<Action, BindSet> parseBindSets(Dictionary<Action, string> keybindStrings)
+        {
+            List<Action> unusedActions = Enum.GetValues(typeof(Action)).Cast<Action>().ToList();
+
+            Dictionary<Action, BindSet> keybinds = new Dictionary<Action, BindSet>();
+
+            // Try to add all from the provided dictionary
+            if (keybindStrings != null)
+            {
+                foreach(Action action in keybindStrings.Keys)
+                {
+                    unusedActions.Remove(action);
+
+                    keybinds.Add(action, new BindSet(keybindStrings[action]));
+                }
+            }
+
+            // Fill any remaining actions from the default
+            foreach (Action action in unusedActions)
+            {
+                keybinds.Add(action, new BindSet(defaultKeybinds[action]));
+            }
+
+            Console.WriteLine("Keybinder: Loaded the following keybinds");
+            foreach (Action action in keybinds.Keys)
+            {
+                Console.WriteLine(action.ToString() + ": " + keybinds[action]);
+            }
+
+            return keybinds;
+        }
+
+        private Dictionary<Action, BindSet> keybinds = new Dictionary<Action, BindSet>();
+
+        public static Keybinder Instance { get; private set; }
+
+        private void Awake()
+        {
+            Instance = this;
+
+            // TODO: add a call to RandomizerIO to get a dictionary read from file
+            // TODO: add a call to RandomizerIO to write file if it didn't exist
+
+            keybinds = parseBindSets(null);
+        }
+
+        /**
+         * Called every frame to update the state of each keybind
+         */
+        private void Update()
+        {
+            foreach (BindSet set in keybinds.Values)
+            {
+                set.UpdateState();
+            }
+        }
+
+        /**
+         * Checks if one of the bindsets is pressed
+         */
+        public static bool IsPressed(Action action)
+        {
+            return Instance.keybinds[action].IsPressed;
+        }
+
+        /**
+         * Checks if one of the bindsets was pressed this frame
+         */
+        public static bool OnPressed(Action action)
+        {
+            return Instance.keybinds[action].OnPressed;
+        }
+    }
+}

--- a/Core/LocalGameState.cs
+++ b/Core/LocalGameState.cs
@@ -20,6 +20,11 @@ namespace OriBFArchipelago.Core
                 return (bool)value;
             }
         }
+
+        public static bool QueueDoubleBash = false;
+        public static bool WasDoubleBashQueued = false;
+        public static bool QueueGrenadeJump = false;
+
         public static void Reset()
         {
             IsGinsoExit = false;

--- a/Core/RandomizerController.cs
+++ b/Core/RandomizerController.cs
@@ -81,7 +81,7 @@ namespace OriBFArchipelago.Core
             if (IsSuspended)
                 return;
 
-            if (UnityEngine.Input.GetKey(KeyCode.LeftAlt) && UnityEngine.Input.GetKeyDown(KeyCode.T))
+            if (Keybinder.OnPressed(Keybinder.Action.OpenTeleport))
             {
                 if (PlayerHasControl)
                 {

--- a/Core/RandomizerController.cs
+++ b/Core/RandomizerController.cs
@@ -81,7 +81,7 @@ namespace OriBFArchipelago.Core
             if (IsSuspended)
                 return;
 
-            if (Keybinder.OnPressed(Keybinder.Action.OpenTeleport))
+            if (Keybinder.OnPressed(KeybindAction.OpenTeleport))
             {
                 if (PlayerHasControl)
                 {

--- a/Core/RandomizerController.cs
+++ b/Core/RandomizerController.cs
@@ -28,7 +28,7 @@ namespace OriBFArchipelago.Core
                 Instance = null;
         }
 
-        public void OpenTeleportMenu()
+        private void OpenTeleportMenu()
         {
             if (Characters.Sein.Active && !Characters.Sein.IsSuspended && Characters.Sein.Controller.CanMove && !UI.MainMenuVisible)
             {
@@ -74,19 +74,91 @@ namespace OriBFArchipelago.Core
             }
         }
 
+        private void ListStones()
+        {
+            if (RandomizerManager.Options.KeyStoneLogic == KeyStoneOptions.Anywhere)
+            {
+                int keyStonesRemaining = RandomizerManager.Receiver.GetItemCount(InventoryItem.KeyStone) -
+                                         RandomizerManager.Receiver.GetItemCount(InventoryItem.KeyStoneUsed);
+                RandomizerMessager.instance.AddMessage("KeyStones remaining: " + keyStonesRemaining);
+            }
+            else if (RandomizerManager.Options.KeyStoneLogic == KeyStoneOptions.AreaSpecific)
+            {
+                int gladesKeyStones = RandomizerManager.Receiver.GetItemCount(InventoryItem.GladesKeyStone) -
+                                      RandomizerManager.Receiver.GetItemCount(InventoryItem.GladesKeyStoneUsed);
+                int grottoKeyStones = RandomizerManager.Receiver.GetItemCount(InventoryItem.GrottoKeyStone) -
+                                      RandomizerManager.Receiver.GetItemCount(InventoryItem.GrottoKeyStoneUsed);
+                int ginsoKeyStones = RandomizerManager.Receiver.GetItemCount(InventoryItem.GinsoKeyStone) -
+                                     RandomizerManager.Receiver.GetItemCount(InventoryItem.GinsoKeyStoneUsed);
+                int swampKeyStones = RandomizerManager.Receiver.GetItemCount(InventoryItem.SwampKeyStone) -
+                                     RandomizerManager.Receiver.GetItemCount(InventoryItem.SwampKeyStoneUsed);
+                int mistyKeyStones = RandomizerManager.Receiver.GetItemCount(InventoryItem.MistyKeyStone) -
+                                     RandomizerManager.Receiver.GetItemCount(InventoryItem.MistyKeyStoneUsed);
+                int forlornKeyStones = RandomizerManager.Receiver.GetItemCount(InventoryItem.ForlornKeyStone) -
+                                       RandomizerManager.Receiver.GetItemCount(InventoryItem.ForlornKeyStoneUsed);
+                int sorrowKeyStones = RandomizerManager.Receiver.GetItemCount(InventoryItem.SorrowKeyStone) -
+                                      RandomizerManager.Receiver.GetItemCount(InventoryItem.SorrowKeyStoneUsed);
+
+                RandomizerMessager.instance.AddMessage("Glades KeyStones remaining: " + gladesKeyStones);
+                RandomizerMessager.instance.AddMessage("Grotto KeyStones remaining: " + grottoKeyStones);
+                RandomizerMessager.instance.AddMessage("Ginso KeyStones remaining: " + ginsoKeyStones);
+                RandomizerMessager.instance.AddMessage("Swamp KeyStones remaining: " + swampKeyStones);
+                RandomizerMessager.instance.AddMessage("Misty KeyStones remaining: " + mistyKeyStones);
+                RandomizerMessager.instance.AddMessage("Forlorn KeyStones remaining: " + forlornKeyStones);
+                RandomizerMessager.instance.AddMessage("Sorrow KeyStones remaining: " + sorrowKeyStones);
+            }
+
+            if (RandomizerManager.Options.MapStoneLogic == MapStoneOptions.Anywhere)
+            {
+                int mapStonesRemaining = RandomizerManager.Receiver.GetItemCount(InventoryItem.MapStone) -
+                                         RandomizerManager.Receiver.GetItemCount(InventoryItem.MapStoneUsed);
+                RandomizerMessager.instance.AddMessage("MapStones remaining: " + mapStonesRemaining);
+            }
+            else if (RandomizerManager.Options.MapStoneLogic == MapStoneOptions.AreaSpecific)
+            {
+                List<InventoryItem> mapStoneList = new List<InventoryItem>
+                    {
+                        InventoryItem.GladesMapStone,
+                        InventoryItem.GroveMapStone,
+                        InventoryItem.GrottoMapStone,
+                        InventoryItem.SwampMapStone,
+                        InventoryItem.ValleyMapStone,
+                        InventoryItem.ForlornMapStone,
+                        InventoryItem.SorrowMapStone,
+                        InventoryItem.HoruMapStone,
+                        InventoryItem.BlackrootMapStone
+                    };
+
+                string mapStoneString = mapStoneList.Where(x => RandomizerManager.Receiver.HasItem(x) && 
+                                                                !RandomizerManager.Receiver.HasItem(x+1))
+                                                    .Select(y => y.ToString())
+                                                    .Join(z => z.ToString(), ", ");
+
+                RandomizerMessager.instance.AddMessage("Current MapStones: " + mapStoneString);
+            }
+        }
+
         public static bool PlayerHasControl => Characters.Sein && Characters.Sein.Controller.CanMove && Characters.Sein.Active;
 
-        private void Update()
+        private void FixedUpdate()
         {
-            if (IsSuspended)
-                return;
-
             if (Keybinder.OnPressed(KeybindAction.OpenTeleport))
             {
                 if (PlayerHasControl)
                 {
                     OpenTeleportMenu();
                 }
+                RandomizerMessager.instance.AddMessage("Pressed teleport");
+            }
+
+            if (Keybinder.OnPressed(KeybindAction.ListStones))
+            {
+                ListStones();
+            }
+
+            if (Keybinder.OnPressed(KeybindAction.GoalProgress))
+            {
+                RandomizerManager.Connection.IsGoalComplete();
             }
         }
     }

--- a/Core/RandomizerController.cs
+++ b/Core/RandomizerController.cs
@@ -88,20 +88,6 @@ namespace OriBFArchipelago.Core
                     OpenTeleportMenu();
                 }
             }
-
-            if (UnityEngine.Input.GetKey(KeyCode.LeftAlt) && UnityEngine.Input.GetKeyDown(KeyCode.M))
-            {
-                if (RandomizerMessager.instance.IsActive)
-                {
-                    RandomizerMessager.instance.AddMessage("Message system deactivated");
-                    RandomizerMessager.instance.SetActive(false);
-                }
-                else
-                {
-                    RandomizerMessager.instance.SetActive(true);
-                    RandomizerMessager.instance.AddMessage("Message system activated");
-                }
-            }
         }
     }
 }

--- a/Core/RandomizerIO.cs
+++ b/Core/RandomizerIO.cs
@@ -143,6 +143,7 @@ namespace OriBFArchipelago.Core
 
         /**
          * Read the dictionary of archipelago slot data associated with all the game's save slots
+         * If the file is not found, it creates a file
          */
         public static bool ReadSlotData(out Dictionary<int, SlotData> data)
         {
@@ -247,6 +248,183 @@ namespace OriBFArchipelago.Core
             catch (IOException e)
             {
                 Console.WriteLine($"Could not write to slot data file: {e}");
+                return false;
+            }
+        }
+
+        /**
+         * Read settings from file
+         * If the file is not found, an empty dictionary is returned and the function returns false
+         */
+        public static bool ReadSettings(out Dictionary<RandomizerSetting, int> settings)
+        {
+            try
+            {
+                string fileName = $"Settings.txt";
+                string fullPath = $"{SAVE_FILE_PATH}\\{fileName}";
+
+                settings = new Dictionary<RandomizerSetting, int>();
+
+                // If file does not exist, return false without error
+                if (!File.Exists(fullPath))
+                {
+                    return false;
+                }
+
+                // otherwise, continue to read the file
+                StreamReader sr = new StreamReader(fullPath);
+
+                // Read each line which has separate slot data
+                string[] lines = sr.ReadToEnd().Split('\n');
+
+                sr.Close();
+
+                foreach (string line in lines)
+                {
+                    string[] pair = line.Split('=');
+
+                    try
+                    {
+                        RandomizerSetting setting = (RandomizerSetting)Enum.Parse(typeof(RandomizerSetting), pair[0].Trim());
+                        int value = int.Parse(pair[1].Trim());
+                        settings.Add(setting, value);
+                    }
+                    catch (Exception)
+                    {
+                        Console.WriteLine($"Invalid inventory data: {pair[0].Trim()}={pair[1].Trim()}");
+                    }
+                }
+
+                return true;
+            }
+            catch (IOException e)
+            {
+                Console.WriteLine($"Could not read settings file: {e}");
+                settings = new Dictionary<RandomizerSetting, int>();
+                return false;
+            }
+        }
+
+        /**
+         * Write setting to file
+         */
+        public static bool WriteSettings(Dictionary<RandomizerSetting, int> settings)
+        {
+            try
+            {
+                string fileName = $"Settings.txt";
+                string fullPath = $"{SAVE_FILE_PATH}\\{fileName}";
+
+                StringBuilder sb = new StringBuilder();
+
+                // Go through rest of inventory to save to file
+                foreach (RandomizerSetting setting in settings.Keys)
+                {
+                    sb.AppendLine($"{setting}={settings[setting]}");
+                }
+
+                // remove last new line character
+                sb.Remove(sb.Length - 1, 1);
+
+                StreamWriter sw = new StreamWriter(fullPath);
+
+                sw.Write(sb.ToString());
+
+                sw.Close();
+
+                return true;
+            }
+            catch (IOException e)
+            {
+                Console.WriteLine($"Could not write to settings file: {e}");
+                return false;
+            }
+        }
+
+        /**
+         * Read keybinds from file
+         * If the file is not found, an empty dictionary is returned and the function returns false
+         */
+        public static bool ReadKeybinds(out Dictionary<KeybindAction, string> keybinds)
+        {
+            try
+            {
+                string fileName = $"Keybinds.txt";
+                string fullPath = $"{SAVE_FILE_PATH}\\{fileName}";
+
+                keybinds = new Dictionary<KeybindAction, string>();
+
+                // If file does not exist, return false without error
+                if (!File.Exists(fullPath))
+                {
+                    return false;
+                }
+
+                // otherwise, continue to read the file
+                StreamReader sr = new StreamReader(fullPath);
+
+                // Read each line which has separate slot data
+                string[] lines = sr.ReadToEnd().Split('\n');
+
+                sr.Close();
+
+                foreach (string line in lines)
+                {
+                    string[] pair = line.Split('=');
+
+                    try
+                    {
+                        KeybindAction keybind = (KeybindAction)Enum.Parse(typeof(KeybindAction), pair[0].Trim());
+                        keybinds.Add(keybind, pair[1].Trim());
+                    }
+                    catch (Exception)
+                    {
+                        Console.WriteLine($"Invalid inventory data: {pair[0].Trim()}={pair[1].Trim()}");
+                    }
+                }
+
+                return true;
+            }
+            catch (IOException e)
+            {
+                Console.WriteLine($"Could not read settings file: {e}");
+                keybinds = new Dictionary<KeybindAction, string>();
+                return false;
+            }
+        }
+
+        /**
+         * Write setting to file
+         */
+        public static bool WriteKeybinds(Dictionary<KeybindAction, string> keybinds)
+        {
+            try
+            {
+                string fileName = $"Keybinds.txt";
+                string fullPath = $"{SAVE_FILE_PATH}\\{fileName}";
+
+                StringBuilder sb = new StringBuilder();
+
+                // Go through rest of inventory to save to file
+                foreach (KeybindAction action in keybinds.Keys)
+                {
+                    sb.AppendLine($"{action}={keybinds[action]}");
+                }
+
+                // remove last new line character
+                sb.Remove(sb.Length - 1, 1);
+
+                StreamWriter sw = new StreamWriter(fullPath);
+
+                sw.Write(sb.ToString());
+
+                sw.Close();
+
+                return true;
+            }
+            catch (IOException e)
+            {
+                Console.WriteLine($"Could not write to keybinds file: {e}");
                 return false;
             }
         }

--- a/Core/RandomizerMessager.cs
+++ b/Core/RandomizerMessager.cs
@@ -15,10 +15,6 @@ namespace OriBFArchipelago.Core
     {
         // maximum number of messages before old messages are deleted so they don't flood the screen
         public const int MAX_MESSAGES = 20;
-        // message duration constants
-        public const float DEFAULT_DURATION = 6f;
-        public const float MIN_DURATION = 2f;
-        public const float MAX_DURATION = 10f;
         // amount of duration time left when fade should begin (should not be larger than min duration
         public const float FADE_THRESHOLD = 2f;
 
@@ -26,18 +22,6 @@ namespace OriBFArchipelago.Core
         public Vector2 baseScreenSize = new Vector2(1920, 1080);
 
         public static RandomizerMessager instance;
-
-        // controls whether messages are added to the queue
-        public bool IsActive { get; private set; }
-
-        // controls how long messages remain on the screen
-        public float MessageDuration { get; private set; }
-
-        // controls when to show message options
-        public bool IsPaused { get; set; }
-
-        // controls whether to show all or only some messages
-        public bool IsVerbose { get; private set; }
 
         public class RandomizerMessage
         {
@@ -60,10 +44,6 @@ namespace OriBFArchipelago.Core
         private void Awake()
         {
             instance = this;
-            IsActive = true;
-            MessageDuration = DEFAULT_DURATION;
-            IsPaused = false;
-            IsVerbose = true;
             messageQueue = new Queue<RandomizerMessage>();
 
             messageStyle = new GUIStyle();
@@ -78,37 +58,10 @@ namespace OriBFArchipelago.Core
 
         private void OnGUI()
         {
-            int optionsOffset = 0;
-
             messageStyle.fontSize = (int)(25 * (Screen.width / baseScreenSize.x));
-            optionsStyle.fontSize = (int)(25 * (Screen.width / baseScreenSize.x));
-
-            // Show options
-            if (IsPaused)
-            {
-                optionsOffset = 100;
-                GUILayout.BeginArea(new Rect(5, 5, Screen.width / 3, 100));
-
-                GUILayout.BeginVertical();
-
-                GUILayout.BeginHorizontal();
-                GUILayout.Label("Message Duration: ", optionsStyle, GUILayout.ExpandWidth(false));
-                MessageDuration = GUILayout.HorizontalSlider(MessageDuration, MIN_DURATION, MAX_DURATION);
-                GUILayout.Label((int)MessageDuration + "", optionsStyle);
-                GUILayout.EndHorizontal();
-
-                GUILayout.BeginHorizontal();
-                GUILayout.Label("Show all messages: ", optionsStyle, GUILayout.ExpandWidth(false));
-                IsVerbose = GUILayout.Toggle(IsVerbose, "");
-                GUILayout.EndHorizontal();
-
-                GUILayout.EndVertical();
-
-                GUILayout.EndArea();
-            }
 
             // Show messages
-            GUILayout.BeginArea(new Rect(5, 5 + optionsOffset, Screen.width / 3, Screen.height));
+            GUILayout.BeginArea(new Rect(5, 5, Screen.width / 3, Screen.height));
 
             GUILayout.BeginVertical();
 
@@ -162,9 +115,9 @@ namespace OriBFArchipelago.Core
 
         public void AddMessage(string message)
         {
-            if (IsActive)
+            if (RandomizerSettings.Get(RandomizerSettings.Setting.MessagerState) != 0)
             {
-                messageQueue.Enqueue(new RandomizerMessage(message, MessageDuration));
+                messageQueue.Enqueue(new RandomizerMessage(message, RandomizerSettings.Get(RandomizerSettings.Setting.MessageDuration)));
             }
         }
 
@@ -192,7 +145,7 @@ namespace OriBFArchipelago.Core
 
                 // always show the message if in verbose mode
                 // or, if not verbose, check for a player message part with the active player
-                if (IsVerbose ||
+                if (RandomizerSettings.Get(RandomizerSettings.Setting.MessagerState) == 2 ||
                     part is PlayerMessagePart && ((PlayerMessagePart)part).IsActivePlayer)
                 {
                     showMessage = true;
@@ -209,11 +162,6 @@ namespace OriBFArchipelago.Core
         {
             byte[] colorData = {color.R, color.G, color.B};
             return BitConverter.ToString(colorData).Replace("-", string.Empty);
-        }
-
-        public void SetActive(bool isActive)
-        {
-            IsActive = isActive;
         }
     }
 }

--- a/Core/RandomizerMessager.cs
+++ b/Core/RandomizerMessager.cs
@@ -115,9 +115,9 @@ namespace OriBFArchipelago.Core
 
         public void AddMessage(string message)
         {
-            if (RandomizerSettings.Get(RandomizerSettings.Setting.MessagerState) != 0)
+            if (RandomizerSettings.Get(RandomizerSetting.MessagerState) != 0)
             {
-                messageQueue.Enqueue(new RandomizerMessage(message, RandomizerSettings.Get(RandomizerSettings.Setting.MessageDuration)));
+                messageQueue.Enqueue(new RandomizerMessage(message, RandomizerSettings.Get(RandomizerSetting.MessageDuration)));
             }
         }
 
@@ -145,7 +145,7 @@ namespace OriBFArchipelago.Core
 
                 // always show the message if in verbose mode
                 // or, if not verbose, check for a player message part with the active player
-                if (RandomizerSettings.Get(RandomizerSettings.Setting.MessagerState) == 2 ||
+                if (RandomizerSettings.Get(RandomizerSetting.MessagerState) == 2 ||
                     part is PlayerMessagePart && ((PlayerMessagePart)part).IsActivePlayer)
                 {
                     showMessage = true;

--- a/Core/RandomizerReceiver.cs
+++ b/Core/RandomizerReceiver.cs
@@ -11,7 +11,7 @@ namespace OriBFArchipelago.Core
     internal class RandomizerReceiver : ISuspendable
     {
         // Version of this randomizer (probably move this to an outer class)
-        private const string VERSION = "0.1.0";
+        private const string VERSION = PluginInfo.PLUGIN_VERSION;
 
         // queue to make sure items are only granted to the player when the player is active and has control
         private Queue<InventoryItem> itemQueue;

--- a/Core/RandomizerSettings.cs
+++ b/Core/RandomizerSettings.cs
@@ -87,8 +87,8 @@ namespace OriBFArchipelago.Core
                 buttonStyle.fontStyle = FontStyle.Bold;
                 buttonStyle.normal.textColor = new Color(1f, 1f, 1f);
 
-                // display in the top right corner
-                GUILayout.BeginArea(new Rect(5, Screen.height * 3 / 4, Screen.width / 3, Screen.height / 4));
+                // display in the bottom left corner
+                GUILayout.BeginArea(new Rect(5, Screen.height * 4 / 5, Screen.width / 3, Screen.height / 5));
 
                 GUILayout.BeginVertical();
 

--- a/Core/RandomizerSettings.cs
+++ b/Core/RandomizerSettings.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing.Text;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace OriBFArchipelago.Core
+{
+    internal class RandomizerSettings : MonoBehaviour
+    {
+        internal enum Setting
+        {
+            DoubleBashAssist, // 0 is off, 1 in on
+            GrenadeJumpAssist, // 0 is off, 1 in on
+            MessagerState, // 0 is none, 1 is local, 2 is all
+            MessageDuration // number of seconds messages stay
+        }
+
+        private static RandomizerSettings instance;
+
+        // Since message duration will be a slider, it needs a min and max
+        private const float MIN_MESSAGE_DURATION = 2f;
+        private const float MAX_MESSAGE_DURATION = 10f;
+
+        private static Dictionary<Setting, int> defaultSettings = new Dictionary<Setting, int>
+        {
+            { Setting.DoubleBashAssist, 1 },
+            { Setting.GrenadeJumpAssist, 1 },
+            { Setting.MessagerState, 2 },
+            { Setting.MessageDuration, 6 }
+        };
+
+        // saves the currently used settings
+        private Dictionary<Setting, int> settings = new Dictionary<Setting, int>();
+
+        // used as a basis to dynamically change the font size
+        private Vector2 baseScreenSize = new Vector2(1920, 1080);
+
+        private GUIStyle textStyle, buttonStyle;
+
+        private void Awake()
+        {
+            settings = defaultSettings;
+            instance = this;
+            ShowSettings = false;
+
+            textStyle = new GUIStyle();
+            textStyle.wordWrap = false;
+            textStyle.fontStyle = FontStyle.Bold;
+            textStyle.normal.textColor = new Color(1f, 1f, 1f);
+
+            // TODO: call RandomizerIO to get settings from file
+            // TODO: write file if file does not exist
+        }
+
+        private void OnGUI()
+        {
+            // Show options
+            if (ShowSettings)
+            {
+                textStyle.fontSize = (int)(25 * (Screen.width / baseScreenSize.x));
+
+                // GetStyle can only be called from within OnGUI, so this needs to be here instead of Awake()
+                buttonStyle = GUI.skin.GetStyle("button");
+                buttonStyle.fontStyle = FontStyle.Bold;
+                buttonStyle.normal.textColor = new Color(1f, 1f, 1f);
+
+                // display in the top right corner
+                GUILayout.BeginArea(new Rect(5, Screen.height * 3 / 4, Screen.width / 3, Screen.height / 4));
+
+                GUILayout.BeginVertical();
+
+                GUILayout.BeginHorizontal();
+                GUILayout.Label("Double Bash Assist: ", textStyle, GUILayout.ExpandWidth(false));
+                settings[Setting.DoubleBashAssist] = GUILayout.Toggle(settings[Setting.DoubleBashAssist] == 1, "") ? 1 : 0;
+                GUILayout.EndHorizontal();
+
+                GUILayout.BeginHorizontal();
+                GUILayout.Label("Grenade Jump Assist: ", textStyle, GUILayout.ExpandWidth(false));
+                settings[Setting.GrenadeJumpAssist] = GUILayout.Toggle(settings[Setting.GrenadeJumpAssist] == 1, "") ? 1 : 0;
+                GUILayout.EndHorizontal();
+
+                GUILayout.BeginHorizontal();
+                GUILayout.Label("Message Duration: ", textStyle, GUILayout.ExpandWidth(false));
+                settings[Setting.MessageDuration] = (int)GUILayout.HorizontalSlider(settings[Setting.MessageDuration], MIN_MESSAGE_DURATION, MAX_MESSAGE_DURATION);
+                GUILayout.Label(settings[Setting.MessageDuration] + "", textStyle);
+                GUILayout.EndHorizontal();
+
+                GUILayout.BeginHorizontal();
+                GUILayout.Label("Show messages: ", textStyle, GUILayout.ExpandWidth(false));
+                string[] stateOptions = { "None", "Minimal", "Verbose" };
+                settings[Setting.MessagerState] = GUILayout.Toolbar(settings[Setting.MessagerState], stateOptions, buttonStyle);
+                GUILayout.EndHorizontal();
+
+                GUILayout.EndVertical();
+
+                GUILayout.EndArea();
+            }
+        }
+
+        public static bool ShowSettings { get; set; }
+
+        public static int Get(Setting setting)
+        {
+            return instance.settings[setting];
+        }
+
+        public static void Save()
+        {
+            // TODO: save settings to file
+            Console.WriteLine("Saving settings...");
+        }
+    }
+}

--- a/OriBFArchipelago.cs
+++ b/OriBFArchipelago.cs
@@ -28,6 +28,7 @@ namespace OriBFArchipelago
             Controllers.Add<RandomizerController>(null, "Randomizer");
             Controllers.Add<RandomizerMessager>(null, "Randomizer");
             Controllers.Add<RandomizerManager>(null, "Randomizer");
+            Controllers.Add<Keybinder>(null, "Randomizer");
         }
     }
 }

--- a/OriBFArchipelago.cs
+++ b/OriBFArchipelago.cs
@@ -29,6 +29,7 @@ namespace OriBFArchipelago
             Controllers.Add<RandomizerMessager>(null, "Randomizer");
             Controllers.Add<RandomizerManager>(null, "Randomizer");
             Controllers.Add<Keybinder>(null, "Randomizer");
+            Controllers.Add<RandomizerSettings>(null, "Randomizer");
         }
     }
 }

--- a/OriBFArchipelago.csproj
+++ b/OriBFArchipelago.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>OriBFArchipelago</AssemblyName>
     <Description>Archipelago client for Ori and the Blind Forest</Description>
-    <Version>0.1.3</Version>
+    <Version>0.2.2</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/Patches/DeathSavePatches.cs
+++ b/Patches/DeathSavePatches.cs
@@ -29,6 +29,7 @@ namespace OriBFArchipelago.Patches
         private static void Postfix(SaveGameController __instance)
         {
             RandomizerManager.Receiver.OnSave();
+            RandomizerSettings.Save();
         }
     }
 }

--- a/Patches/DoubleBashPatches.cs
+++ b/Patches/DoubleBashPatches.cs
@@ -1,0 +1,96 @@
+﻿using Core;
+using HarmonyLib;
+using OriBFArchipelago.Core;
+using System.Reflection;
+using UnityEngine;
+using Input = Core.Input;
+
+namespace OriBFArchipelago.Patches
+{
+    /**
+     * Modifed from https://github.com/sparkle-preference/OriDERandomizer/blob/master/modified_classes/SeinBashAttack.cs
+     */
+    [HarmonyPatch(typeof(SeinBashAttack), nameof(SeinBashAttack.UpdateNormalState))]
+    internal class BashAttackUpdateStatePatch
+    {
+        private static bool Prefix(SeinBashAttack __instance)
+        {
+            // Get the private field from __instance required to recreate this function
+            float m_timeRemainingOfBashButtonPress = (float)AccessTools.Field(typeof(SeinBashAttack), "m_timeRemainingOfBashButtonPress").GetValue(__instance);
+
+            // Save whether a double bash was queued
+            LocalGameState.WasDoubleBashQueued = LocalGameState.QueueDoubleBash;
+
+            // Play the sound normally and when an extra is queued
+            if (Input.Bash.OnPressed || LocalGameState.QueueDoubleBash)
+            {
+                LocalGameState.QueueDoubleBash = false;
+                m_timeRemainingOfBashButtonPress = 0.5f;
+                if (__instance.Sein.IsOnGround && 
+                    __instance.Sein.Speed.x == 0f && 
+                    !SeinAbilityRestrictZone.IsInside(SeinAbilityRestrictZoneMode.AllAbilities) && 
+                    !__instance.Sein.Abilities.Carry.IsCarrying)
+                {
+                    __instance.Sein.Animation.Play(__instance.BackFlipAnimation, 10, null);
+                    __instance.Sein.PlatformBehaviour.PlatformMovement.LocalSpeedY = __instance.BackFlipSpeed;
+                    if ((!__instance.Sein.PlayerAbilities.BashBuff.HasAbility) ? __instance.StationaryBashSound : __instance.UpgradedStationaryBashSound)
+                    {
+                        Sound.Play((!__instance.Sein.PlayerAbilities.BashBuff.HasAbility) ? __instance.StationaryBashSound.GetSound(null) : __instance.UpgradedStationaryBashSound.GetSound(null), __instance.transform.position, null);
+                    }
+                }
+            }
+
+            if (m_timeRemainingOfBashButtonPress > 0f)
+            {
+                m_timeRemainingOfBashButtonPress -= Time.deltaTime;
+                if ((Input.Bash.OnReleased || 
+                    ((double)m_timeRemainingOfBashButtonPress <= 0.4 && 
+                    (double)m_timeRemainingOfBashButtonPress >= 0.4 - (double)Time.deltaTime)) && 
+                    !SeinAbilityRestrictZone.IsInside(SeinAbilityRestrictZoneMode.AllAbilities) && 
+                    !__instance.Sein.Abilities.Carry.IsCarrying)
+                {
+                    __instance.BashFailed();
+                }
+                if (Input.Bash.Released || m_timeRemainingOfBashButtonPress <= 0f)
+                {
+                    m_timeRemainingOfBashButtonPress = 0f;
+                }
+            }
+
+            // Begin bash normally or if a bash was queued
+            if ((m_timeRemainingOfBashButtonPress > 0f || LocalGameState.WasDoubleBashQueued) && __instance.CanBash)
+            {
+                __instance.BeginBash();
+            }
+
+            // Invoke private methods of SeinBashAttack
+            AccessTools.Method(typeof(SeinBashAttack), "HandleFindingTarget").Invoke(__instance, []);
+            AccessTools.Method(typeof(SeinBashAttack), "UpdateTargetHighlight").Invoke(__instance, [__instance.Target]);
+
+            return false;
+        }
+    }
+
+    /**
+     * Modifed from https://github.com/sparkle-preference/OriDERandomizer/blob/master/modified_classes/BashAttackGame.cs
+     */
+    [HarmonyPatch]
+    internal class BashAttackGameFinishedPatch
+    {
+        // Need to use this method because BashAttackGame is an internal class
+        static MethodBase TargetMethod()
+        {
+            return AccessTools.TypeByName("BashAttackGame").GetMethod("GameFinished", AccessTools.allDeclared);
+        }
+
+        private static void Postfix()
+        {
+            // Queue a double bash if the button is pressed and a double bash wasn't previously queued
+            if (Keybinder.IsPressed(Keybinder.Action.DoubleBash) && !LocalGameState.WasDoubleBashQueued)
+            {
+                LocalGameState.QueueDoubleBash = true;
+            }
+            LocalGameState.WasDoubleBashQueued = false;
+        }
+    }
+}

--- a/Patches/DoubleBashPatches.cs
+++ b/Patches/DoubleBashPatches.cs
@@ -85,8 +85,10 @@ namespace OriBFArchipelago.Patches
 
         private static void Postfix()
         {
-            // Queue a double bash if the button is pressed and a double bash wasn't previously queued
-            if (Keybinder.IsPressed(Keybinder.Action.DoubleBash) && !LocalGameState.WasDoubleBashQueued)
+            // Queue a double bash if the setting is enabled, the button is pressed, and a double bash wasn't previously queued
+            if (RandomizerSettings.Get(RandomizerSettings.Setting.DoubleBashAssist) == 1 && 
+                Keybinder.IsPressed(Keybinder.Action.DoubleBash) && 
+                !LocalGameState.WasDoubleBashQueued)
             {
                 LocalGameState.QueueDoubleBash = true;
             }

--- a/Patches/DoubleBashPatches.cs
+++ b/Patches/DoubleBashPatches.cs
@@ -86,13 +86,38 @@ namespace OriBFArchipelago.Patches
         private static void Postfix()
         {
             // Queue a double bash if the setting is enabled, the button is pressed, and a double bash wasn't previously queued
-            if (RandomizerSettings.Get(RandomizerSettings.Setting.DoubleBashAssist) == 1 && 
-                Keybinder.IsPressed(Keybinder.Action.DoubleBash) && 
+            if (RandomizerSettings.Get(RandomizerSetting.DoubleBashAssist) == 1 && 
+                Keybinder.IsPressed(KeybindAction.DoubleBash) && 
                 !LocalGameState.WasDoubleBashQueued)
             {
                 LocalGameState.QueueDoubleBash = true;
             }
             LocalGameState.WasDoubleBashQueued = false;
+        }
+    }
+
+    /**
+     * Modifed from https://github.com/sparkle-preference/OriDERandomizer/blob/master/modified_classes/BashAttackGame.cs
+     */
+    [HarmonyPatch]
+    internal class BashAttackGamePlayingStatePatch
+    {
+        // Need to use this method because BashAttackGame is an internal class
+        static MethodBase TargetMethod()
+        {
+            return AccessTools.TypeByName("BashAttackGame").GetMethod("UpdatePlayingState", AccessTools.allDeclared);
+        }
+
+        private static void Postfix(Object __instance)
+        {
+            // If Bash Tap is enabled and the button is pressed, end the bash game
+            if (!Input.Bash.Released &&
+                (RandomizerSettings.Get(RandomizerSetting.BashTap) == 1 &&
+                Keybinder.OnPressed(KeybindAction.DoubleBash)))
+            {
+                AccessTools.TypeByName("BashAttackGame").GetMethod("GameFinished", AccessTools.allDeclared)
+                    .Invoke(__instance, []);
+            }
         }
     }
 }

--- a/Patches/GrenadeJumpPatch.cs
+++ b/Patches/GrenadeJumpPatch.cs
@@ -21,8 +21,12 @@ namespace OriBFArchipelago.Patches
 
             bool grenadeJumpPressed = false;
             bool grenadeJumpHeld = false;
-            grenadeJumpPressed = Keybinder.OnPressed(Keybinder.Action.GrenadeJump);
-            grenadeJumpHeld = Keybinder.IsPressed(Keybinder.Action.GrenadeJump);
+            // only enable grenade jump if the assist is enabled
+            if (RandomizerSettings.Get(RandomizerSettings.Setting.GrenadeJumpAssist) == 1)
+            {
+                grenadeJumpPressed = Keybinder.OnPressed(Keybinder.Action.GrenadeJump);
+                grenadeJumpHeld = Keybinder.IsPressed(Keybinder.Action.GrenadeJump);
+            }
 
             // If grenade jump is queued, activate the correct controls to initiate the jump
             if (LocalGameState.QueueGrenadeJump)

--- a/Patches/GrenadeJumpPatch.cs
+++ b/Patches/GrenadeJumpPatch.cs
@@ -1,0 +1,57 @@
+﻿using Game;
+using HarmonyLib;
+using OriBFArchipelago.Core;
+using System;
+using Input = Core.Input;
+
+namespace OriBFArchipelago.Patches
+{
+    /**
+     * Modified from https://github.com/sparkle-preference/OriDERandomizer/blob/master/modified_classes/SeinController.cs
+     */
+    [HarmonyPatch(typeof(SeinController), nameof(SeinController.HandleJumping))]
+    internal class GrenadeJumpPatch
+    {
+        private static void Prefix(SeinController __instance)
+        {
+            if (__instance.IgnoreControllerInput || __instance.LockMovementInput || !__instance.CanMove)
+            {
+                return;
+            }
+
+            bool grenadeJumpPressed = false;
+            bool grenadeJumpHeld = false;
+            grenadeJumpPressed = Keybinder.OnPressed(Keybinder.Action.GrenadeJump);
+            grenadeJumpHeld = Keybinder.IsPressed(Keybinder.Action.GrenadeJump);
+
+            // If grenade jump is queued, activate the correct controls to initiate the jump
+            if (LocalGameState.QueueGrenadeJump)
+            {
+                LocalGameState.QueueGrenadeJump = false;
+                if (grenadeJumpHeld && 
+                    CharacterState.IsActive(__instance.Sein.Abilities.WallChargeJump) && 
+                    __instance.Sein.Abilities.GrabWall && 
+                    __instance.Sein.Abilities.WallChargeJump.CanChargeJump && 
+                    __instance.IsAimingGrenade)
+                {
+                    Input.LeftShoulder.IsPressed = true;
+                    Input.Jump.IsPressed = true;
+                }
+            }
+
+            // If grenade jump is pressed, queue grenade jump for the next frame
+            if (grenadeJumpPressed && 
+                CharacterState.IsActive(Characters.Sein.Abilities.WallChargeJump) &&
+                Characters.Sein.Abilities.GrabWall &&
+                Characters.Sein.Abilities.WallChargeJump.CanChargeJump &&
+                Characters.Sein.Abilities.Grenade &&
+                Characters.Sein.Abilities.Grenade.CanAim && 
+                !__instance.IsAimingGrenade)
+            {
+                LocalGameState.QueueGrenadeJump = true;
+                Input.LeftShoulder.IsPressed = true;
+                Input.Jump.IsPressed = false;
+            }
+        }
+    }
+}

--- a/Patches/GrenadeJumpPatch.cs
+++ b/Patches/GrenadeJumpPatch.cs
@@ -22,10 +22,10 @@ namespace OriBFArchipelago.Patches
             bool grenadeJumpPressed = false;
             bool grenadeJumpHeld = false;
             // only enable grenade jump if the assist is enabled
-            if (RandomizerSettings.Get(RandomizerSettings.Setting.GrenadeJumpAssist) == 1)
+            if (RandomizerSettings.Get(RandomizerSetting.GrenadeJumpAssist) == 1)
             {
-                grenadeJumpPressed = Keybinder.OnPressed(Keybinder.Action.GrenadeJump);
-                grenadeJumpHeld = Keybinder.IsPressed(Keybinder.Action.GrenadeJump);
+                grenadeJumpPressed = Keybinder.OnPressed(KeybindAction.GrenadeJump);
+                grenadeJumpHeld = Keybinder.IsPressed(KeybindAction.GrenadeJump);
             }
 
             // If grenade jump is queued, activate the correct controls to initiate the jump

--- a/Patches/PauseMenuPatches.cs
+++ b/Patches/PauseMenuPatches.cs
@@ -9,7 +9,7 @@ namespace OriBFArchipelago.Patches
     {
         static bool Prefix()
         {
-            RandomizerMessager.instance.IsPaused = true;
+            RandomizerSettings.ShowSettings = true;
             return true;
         }
     }
@@ -19,7 +19,7 @@ namespace OriBFArchipelago.Patches
     {
         static bool Prefix()
         {
-            RandomizerMessager.instance.IsPaused = false;
+            RandomizerSettings.ShowSettings = false;
             return true;
         }
     }


### PR DESCRIPTION
Added Keybinder class to control keybinds and allow for users to change them
Added keybinds for easier Double Bash and Grenade Jump 
Added keybinds to show information about remaining keystones and mapstones
Added RandomizerSettings class to control any local settings for the player. This includes whether to enabled double bash and grenade jump controls, double bash tap, message duration, and messages shown
Messages shown is Verbose (all messages), Minimal (only local messages and those that include the slot's name), and None