### PR TITLE
Grotto and forlorn fixes

### DIFF
--- a/Core/LocalGameState.cs
+++ b/Core/LocalGameState.cs
@@ -25,11 +25,17 @@ namespace OriBFArchipelago.Core
         public static bool QueueDoubleBash = false;
         public static bool WasDoubleBashQueued = false;
         public static bool QueueGrenadeJump = false;
+        public static bool TeleportNightberry = false;
 
         public static void Reset()
         {
             IsGinsoExit = false;
+            IsGrottoBridgeFalling = false;
             IsPendingCheckpoint = false;
+            QueueDoubleBash = false;
+            WasDoubleBashQueued = false;
+            QueueGrenadeJump = false;
+            TeleportNightberry = false;
         }
     }
 }

--- a/Core/LocalGameState.cs
+++ b/Core/LocalGameState.cs
@@ -10,6 +10,7 @@ namespace OriBFArchipelago.Core
     internal class LocalGameState
     {
         public static bool IsGinsoExit = false;
+        public static bool IsGrottoBridgeFalling = false;
         public static bool IsPendingCheckpoint = false;
         public static bool IsTeleporting { 
             get

--- a/Core/RandomizerBootstrap.cs
+++ b/Core/RandomizerBootstrap.cs
@@ -35,6 +35,7 @@ namespace OriBFArchipelago.Core
 
                 // Forlorn Fixes
                 ["forlornRuinsResurrection"] = BootstrapForlornRuinsResurrection,
+                ["forlornRuinsC"] = BootstrapForlornRuinsC,
 
                 // Grotto Fixes
                 ["moonGrottoRopeBridge"] = BootstrapGrottoRopeBridge,
@@ -249,6 +250,41 @@ namespace OriBFArchipelago.Core
             bool hasEscaped = RandomizerManager.Connection.IsForlornEscapeComplete();
             sceneRoot.transform.Find("floatZone").gameObject.SetActive(hasEscaped);
         }
+
+        private static void BootstrapForlornRuinsC(SceneRoot sceneRoot)
+        {
+            // force the animation of the bridge coming down to play upon entering the area
+            ActionSequence entranceSequence = sceneRoot.transform.Find("*forlornEntranceLoad").GetComponent<ActionSequence>();
+            GameObject bridgeGravity = sceneRoot.transform.Find("*setupGravity/timelineSequence").gameObject;
+            BaseAnimatorAction bridgeGravityAction = InsertAction<BaseAnimatorAction>(entranceSequence, 8, new MoonGuid(-1289139173, 680722594, 558787458, 1729657920), sceneRoot);
+            bridgeGravityAction.Target = bridgeGravity;
+            bridgeGravityAction.Animators = [bridgeGravity.GetComponent<BaseAnimator>()];
+            bridgeGravityAction.AnimatorsMode = BaseAnimatorAction.FindAnimatorsMode.GameObject;
+            bridgeGravityAction.Command = BaseAnimatorAction.PlayMode.Restart;
+
+            // remove the cutscene to place the nightberry
+            GameObject nightberryCutscene = sceneRoot.transform.Find("*setupGravity/pedestalAction/*setups/triggers/cutsceneCollisionTrigger").gameObject;
+            ConstantCondition cutsceneCondition = nightberryCutscene.AddComponent<ConstantCondition>();
+            nightberryCutscene.GetComponent<PlayerCollisionStayTrigger>().Condition = cutsceneCondition;
+            cutsceneCondition.IsTrue = false;
+
+            // activate the bridge colliders
+            GameObject roomSetup = sceneRoot.transform.Find("*setupGravity").gameObject;
+            GameObject bridgeColliders = sceneRoot.transform.Find("*setupGravity/timelineSequence/bridgeColliders").gameObject;
+            ActivateBasedOnCondition bridgeActivator = roomSetup.AddComponent<ActivateBasedOnCondition>();
+            ConstantCondition bridgeCondition = roomSetup.AddComponent<ConstantCondition>();
+            bridgeActivator.Condition = bridgeCondition;
+            bridgeActivator.Target = bridgeColliders;
+            bridgeCondition.IsTrue = true;
+
+            // deactivate the door to the laser room
+            GameObject laserDoor = sceneRoot.transform.Find("*setupGravity/solidWallSetup").gameObject;
+            ActivateBasedOnCondition doorActivator = roomSetup.AddComponent<ActivateBasedOnCondition>();
+            ConstantCondition doorCondition = roomSetup.AddComponent<ConstantCondition>();
+            doorActivator.Condition = doorCondition;
+            doorActivator.Target = laserDoor;
+            doorCondition.IsTrue = false;
+        }
         #endregion
 
         #region Valley Fixes
@@ -270,7 +306,7 @@ namespace OriBFArchipelago.Core
         private static void BootstrapGrottoRopeBridge(SceneRoot sceneRoot)
         {
             ActionSequence fallingSequence = sceneRoot.transform.Find("*gumoBridgeSetup/group/action").GetComponent<ActionSequence>();
-            SetGrottoBridgeFallingAction fallingAction = InsertAction<SetGrottoBridgeFallingAction>(fallingSequence, 8, new MoonGuid(-1289149173, 680822594, 558787458, 1729667919), sceneRoot);
+            SetGrottoBridgeFallingAction fallingAction = InsertAction<SetGrottoBridgeFallingAction>(fallingSequence, 8, new MoonGuid(-1289139173, 680722594, 558787458, 1729657921), sceneRoot);
             fallingAction.IsTrue = true;
         }
         
@@ -281,7 +317,7 @@ namespace OriBFArchipelago.Core
             landSetupTrigger.Condition = fallingCondition;
             
             ActionSequence landSequence = sceneRoot.transform.Find("*landSetup/sequence").GetComponent<ActionSequence>();
-            SetGrottoBridgeFallingAction fallingAction = InsertAction<SetGrottoBridgeFallingAction>(landSequence, 0, new MoonGuid(-1289139173, 680722594, 558787458, 1729657919), sceneRoot);
+            SetGrottoBridgeFallingAction fallingAction = InsertAction<SetGrottoBridgeFallingAction>(landSequence, 0, new MoonGuid(-1289139173, 680722594, 558787458, 1729657922), sceneRoot);
             fallingAction.IsTrue = false;
         }
         #endregion
@@ -361,7 +397,6 @@ namespace OriBFArchipelago.Core
         public override void Perform(IContext context)
         {
             LocalGameState.IsGrottoBridgeFalling = IsTrue;
-            System.Console.WriteLine("Bridge Falling set to " + IsTrue);
         }
     }
 

--- a/Core/RandomizerBootstrap.cs
+++ b/Core/RandomizerBootstrap.cs
@@ -36,6 +36,9 @@ namespace OriBFArchipelago.Core
                 // Forlorn Fixes
                 ["forlornRuinsResurrection"] = BootstrapForlornRuinsResurrection,
 
+                // Grotto Fixes
+                ["moonGrottoRopeBridge"] = BootstrapGrottoRopeBridge,
+                ["moonGrottoGumosHideoutB"] = BootstrapGumosHideoutB
             };
         }
 
@@ -248,7 +251,7 @@ namespace OriBFArchipelago.Core
         }
         #endregion
 
-        #region Stomp Triggers
+        #region Valley Fixes
         private static void BootstrapValleyOfTheWindBackground(SceneRoot sceneRoot)
         {
             var deathZoneTrigger = sceneRoot.transform.Find("*getFeatherSetupContainer/*kuroHideSetup/kuroDeathZones").GetComponent<ActivateBasedOnCondition>();
@@ -260,6 +263,26 @@ namespace OriBFArchipelago.Core
             UnityEngine.Object.Destroy(kuroCliffTriggerCollider.Condition);
             var kuroCliffCondition = kuroCliffTriggerCollider.gameObject.AddComponent<StompTriggerCondition>();
             kuroCliffTriggerCollider.Condition = kuroCliffCondition;
+        }
+        #endregion
+
+        #region Grotto Fixes
+        private static void BootstrapGrottoRopeBridge(SceneRoot sceneRoot)
+        {
+            ActionSequence fallingSequence = sceneRoot.transform.Find("*gumoBridgeSetup/group/action").GetComponent<ActionSequence>();
+            SetGrottoBridgeFallingAction fallingAction = InsertAction<SetGrottoBridgeFallingAction>(fallingSequence, 8, new MoonGuid(-1289149173, 680822594, 558787458, 1729667919), sceneRoot);
+            fallingAction.IsTrue = true;
+        }
+        
+        private static void BootstrapGumosHideoutB(SceneRoot sceneRoot)
+        {
+            PlayerCollisionTrigger landSetupTrigger = sceneRoot.transform.Find("*landSetup/trigger").GetComponent<PlayerCollisionTrigger>();
+            IsGrottoBridgeFallingCondition fallingCondition = landSetupTrigger.gameObject.AddComponent<IsGrottoBridgeFallingCondition>();
+            landSetupTrigger.Condition = fallingCondition;
+            
+            ActionSequence landSequence = sceneRoot.transform.Find("*landSetup/sequence").GetComponent<ActionSequence>();
+            SetGrottoBridgeFallingAction fallingAction = InsertAction<SetGrottoBridgeFallingAction>(landSequence, 0, new MoonGuid(-1289139173, 680722594, 558787458, 1729657919), sceneRoot);
+            fallingAction.IsTrue = false;
         }
         #endregion
     }
@@ -317,6 +340,36 @@ namespace OriBFArchipelago.Core
         public override void Perform(IContext context)
         {
             LocalGameState.IsGinsoExit = true;
+        }
+    }
+
+    // Used purely for debugging purposes
+    internal class LogMessageAction : ActionMethod
+    {
+        public string message = "";
+
+        public override void Perform(IContext context)
+        {
+            Console.WriteLine(message);
+        }
+    }
+
+    internal class SetGrottoBridgeFallingAction : ActionMethod
+    {
+        public bool IsTrue = true;
+
+        public override void Perform(IContext context)
+        {
+            LocalGameState.IsGrottoBridgeFalling = IsTrue;
+            System.Console.WriteLine("Bridge Falling set to " + IsTrue);
+        }
+    }
+
+    internal class IsGrottoBridgeFallingCondition: Condition
+    {
+        public override bool Validate(IContext context)
+        {
+            return LocalGameState.IsGrottoBridgeFalling;
         }
     }
 

--- a/Core/RandomizerController.cs
+++ b/Core/RandomizerController.cs
@@ -159,6 +159,13 @@ namespace OriBFArchipelago.Core
             {
                 RandomizerManager.Connection.IsGoalComplete();
             }
+
+            if (LocalGameState.TeleportNightberry && PlayerHasControl && Items.NightBerry != null)
+            {
+                // teleport the nightberry to the location of the forlorn teleporter
+                Items.NightBerry.transform.position = new Vector3(-910f, -300f);
+                LocalGameState.TeleportNightberry = false;
+            }
         }
     }
 }

--- a/Core/RandomizerController.cs
+++ b/Core/RandomizerController.cs
@@ -148,7 +148,6 @@ namespace OriBFArchipelago.Core
                 {
                     OpenTeleportMenu();
                 }
-                RandomizerMessager.instance.AddMessage("Pressed teleport");
             }
 
             if (Keybinder.OnPressed(KeybindAction.ListStones))

--- a/Core/RandomizerIO.cs
+++ b/Core/RandomizerIO.cs
@@ -57,7 +57,15 @@ namespace OriBFArchipelago.Core
 
                 foreach (string line in data)
                 {
+                    if (string.IsNullOrEmpty(line)) continue;
+
                     string[] pair = line.Split('=');
+
+                    if (pair.Length != 2)
+                    {
+                        Console.WriteLine($"Incorrect format for inventory data: {line}");
+                        continue;
+                    }
 
                     try
                     {
@@ -171,7 +179,16 @@ namespace OriBFArchipelago.Core
 
                 foreach (string line in lines)
                 {
+                    if (string.IsNullOrEmpty(line)) continue;
+
                     string[] parts = line.Split(',');
+
+                    if (parts.Length != 5)
+                    {
+                        Console.WriteLine($"Incorrect format for slot data: {line}");
+                        continue;
+                    }
+
                     SlotData slotData = new SlotData();
                     slotData.serverName = parts[1];
                     slotData.slotName = parts[2];
@@ -281,7 +298,15 @@ namespace OriBFArchipelago.Core
 
                 foreach (string line in lines)
                 {
+                    if (string.IsNullOrEmpty(line)) continue;
+
                     string[] pair = line.Split('=');
+
+                    if (pair.Length != 2)
+                    {
+                        Console.WriteLine($"Incorrect format for setting data: {line}");
+                        continue;
+                    }
 
                     try
                     {
@@ -291,7 +316,7 @@ namespace OriBFArchipelago.Core
                     }
                     catch (Exception)
                     {
-                        Console.WriteLine($"Invalid inventory data: {pair[0].Trim()}={pair[1].Trim()}");
+                        Console.WriteLine($"Invalid settings data: {pair[0].Trim()}={pair[1].Trim()}");
                     }
                 }
 
@@ -370,7 +395,15 @@ namespace OriBFArchipelago.Core
 
                 foreach (string line in lines)
                 {
+                    if (string.IsNullOrEmpty(line)) continue;
+
                     string[] pair = line.Split('=');
+
+                    if (pair.Length != 2)
+                    {
+                        Console.WriteLine($"Incorrect format for keybind data: {line}");
+                        continue;
+                    }
 
                     try
                     {
@@ -379,7 +412,7 @@ namespace OriBFArchipelago.Core
                     }
                     catch (Exception)
                     {
-                        Console.WriteLine($"Invalid inventory data: {pair[0].Trim()}={pair[1].Trim()}");
+                        Console.WriteLine($"Invalid keybind data: {pair[0].Trim()}={pair[1].Trim()}");
                     }
                 }
 
@@ -387,7 +420,7 @@ namespace OriBFArchipelago.Core
             }
             catch (IOException e)
             {
-                Console.WriteLine($"Could not read settings file: {e}");
+                Console.WriteLine($"Could not read keybinds file: {e}");
                 keybinds = new Dictionary<KeybindAction, string>();
                 return false;
             }

--- a/OriBFArchipelago.csproj
+++ b/OriBFArchipelago.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>OriBFArchipelago</AssemblyName>
     <Description>Archipelago client for Ori and the Blind Forest</Description>
-    <Version>0.2.3</Version>
+    <Version>0.2.4</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/Patches/TeleporterControllerPatch.cs
+++ b/Patches/TeleporterControllerPatch.cs
@@ -135,5 +135,14 @@ namespace OriBFArchipelago.Patches
                 LocalGameState.IsPendingCheckpoint = false;
             }
         }
+
+        [HarmonyPostfix, HarmonyPatch(nameof(TeleporterController.BeginTeleportation))]
+        private static void BeginTeleportationPostfix(GameMapTeleporter selectedTeleporter)
+        {
+            if (selectedTeleporter.Area.Area.AreaNameString == "Forlorn Ruins")
+            {
+                LocalGameState.TeleportNightberry = true;
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes
- If the player enters the Moon Grotto from Blackroot Burrows, their input does not get locked later when triggering the bridge collapse cutscene
- The file IO is now more robust and will not cause errors when finding empty or misconfigured lines

Changes
- The forlorn orb (aka nightberry) will teleport to the player when they teleport into the Forlorn Ruins
- In the room beyond the Forlorn Ruins keystone door, the bridge is already down, the door is open, and the player does not need to hand in the nightberry
