### PR TITLE
Goal modes and more

### DIFF
--- a/Core/ArchipelagoConnection.cs
+++ b/Core/ArchipelagoConnection.cs
@@ -189,6 +189,9 @@ namespace OriBFArchipelago.Core
                 if (RandomizerManager.Options.MapStoneLogic == MapStoneOptions.Progressive &&
                     mapLocations.Contains(location))
                 {
+                    // track the original location in addition to the progressive location
+                    RandomizerManager.Receiver.CheckLocation(location);
+
                     int nextMap = RandomizerManager.Receiver.GetItemCount(InventoryItem.MapStoneUsed);
                     location = "ProgressiveMap" + nextMap;
                 }
@@ -321,8 +324,7 @@ namespace OriBFArchipelago.Core
                         message.Remove(message.Length - 2, 2); // remove last comma
                     }
                 }
-                else if (RandomizerManager.Options.Goal == GoalOptions.AllMaps &&
-                    RandomizerManager.Options.MapStoneLogic != MapStoneOptions.Progressive)
+                else if (RandomizerManager.Options.Goal == GoalOptions.AllMaps)
                 {
                     int countMaps = 0;
                     List<string> uncheckedMaps = new List<string>();
@@ -348,13 +350,6 @@ namespace OriBFArchipelago.Core
                         }
                         message.Remove(message.Length - 2, 2); // remove last comma
                     }
-                }
-                else if (RandomizerManager.Options.Goal == GoalOptions.AllMaps &&
-                    RandomizerManager.Options.MapStoneLogic == MapStoneOptions.Progressive)
-                {
-                    int mapstoneUsed = RandomizerManager.Receiver.GetItemCount(InventoryItem.MapStoneUsed);
-                    hasMetGoal = mapstoneUsed == 9;
-                    message.Append($"{mapstoneUsed} of out 9 maps checked. ");
                 }
                 else if (RandomizerManager.Options.Goal == GoalOptions.WarmthFragments)
                 {

--- a/Core/ArchipelagoConnection.cs
+++ b/Core/ArchipelagoConnection.cs
@@ -175,18 +175,24 @@ namespace OriBFArchipelago.Core
          */
         public async void CheckLocation(string location)
         {
+            if (location is null)
+            {
+                Console.WriteLine("Invalid location: " + location);
+                return;
+            }
+
             if (Connected)
             {
-                if (location is not null)
+                if (RandomizerManager.Options.MapStoneLogic == MapStoneOptions.Progressive &&
+                    mapLocations.Contains(location))
                 {
-                    long locationId = session.Locations.GetLocationIdFromName(GAME_NAME, location);
-                    await Task.Factory.StartNew(() => session.Locations.CompleteLocationChecks(locationId));
-                    Console.WriteLine("Checked " + location);
+                    int nextMap = RandomizerManager.Receiver.GetItemCount(InventoryItem.MapStoneUsed);
+                    location = "ProgressiveMap" + nextMap;
                 }
-                else
-                {
-                    Console.WriteLine("Invalid location: " + location);
-                }
+
+                long locationId = session.Locations.GetLocationIdFromName(GAME_NAME, location);
+                await Task.Factory.StartNew(() => session.Locations.CompleteLocationChecks(locationId));
+                Console.WriteLine("Checked " + location);
             }
             else
             {
@@ -340,6 +346,13 @@ namespace OriBFArchipelago.Core
                         }
                         message.Remove(message.Length - 2, 2); // remove last comma
                     }
+                }
+                else if (RandomizerManager.Options.Goal == GoalOptions.AllMaps &&
+                    RandomizerManager.Options.MapStoneLogic == MapStoneOptions.Progressive)
+                {
+                    int mapstoneUsed = RandomizerManager.Receiver.GetItemCount(InventoryItem.MapStoneUsed);
+                    hasMetGoal = mapstoneUsed == 9;
+                    message.Append($"{mapstoneUsed} of out 9 maps checked. ");
                 }
                 else if (RandomizerManager.Options.Goal == GoalOptions.WarmthFragments)
                 {

--- a/Core/ArchipelagoConnection.cs
+++ b/Core/ArchipelagoConnection.cs
@@ -111,6 +111,9 @@ namespace OriBFArchipelago.Core
             return Connected;
         }
 
+        /**
+         * Called every frame
+         */
         public void Update()
         {
             if (queueDeath &&
@@ -198,6 +201,8 @@ namespace OriBFArchipelago.Core
             {
                 Console.WriteLine("Checked " + location + " but not connected");
             }
+
+            RandomizerManager.Receiver.CheckLocation(location);
         }
 
         /**
@@ -288,7 +293,6 @@ namespace OriBFArchipelago.Core
             {
                 bool hasMetGoal = true;
                 StringBuilder message = new StringBuilder();
-                ReadOnlyCollection<long> checkedLocations = session.Locations.AllLocationsChecked;
 
                 if (RandomizerManager.Options.Goal == GoalOptions.AllSkillTrees)
                 {
@@ -296,8 +300,7 @@ namespace OriBFArchipelago.Core
                     List<string> uncheckedTrees = new List<string>();
                     foreach (string goalLocation in skillTreeLocations)
                     {
-                        long id = session.Locations.GetLocationIdFromName(GAME_NAME, goalLocation);
-                        if (!checkedLocations.Contains(id))
+                        if (!RandomizerManager.Receiver.IsLocationChecked(goalLocation))
                         {
                             hasMetGoal = false;
                             uncheckedTrees.Add(goalLocation);
@@ -325,8 +328,7 @@ namespace OriBFArchipelago.Core
                     List<string> uncheckedMaps = new List<string>();
                     foreach (string goalLocation in mapLocations)
                     {
-                        long id = session.Locations.GetLocationIdFromName(GAME_NAME, goalLocation);
-                        if (!checkedLocations.Contains(id))
+                        if (!RandomizerManager.Receiver.IsLocationChecked(goalLocation))
                         {
                             hasMetGoal = false;
                             uncheckedMaps.Add(goalLocation);
@@ -387,51 +389,6 @@ namespace OriBFArchipelago.Core
                 RandomizerMessager.instance.AddMessage(message.ToString());
 
                 return hasMetGoal;
-            }
-            else
-            {
-                return false;
-            }
-        }
-
-        /**
-         * Check if the ginso escape has been complete
-         */
-        public bool IsGinsoEscapeComplete()
-        {
-            if (Connected)
-            {
-                ReadOnlyCollection<long> checkedLocations = session.Locations.AllLocationsChecked;
-                long id = session.Locations.GetLocationIdFromName(GAME_NAME, "GinsoEscapeExit");
-                if (checkedLocations.Contains(id))
-                {
-                    return true;
-                }
-                else
-                {
-                    return false;
-                }
-            }
-            else
-            {
-                return false;
-            }
-        }
-
-        public bool IsForlornEscapeComplete()
-        {
-            if (Connected)
-            {
-                ReadOnlyCollection<long> checkedLocations = session.Locations.AllLocationsChecked;
-                long id = session.Locations.GetLocationIdFromName(GAME_NAME, "ForlornEscape");
-                if (checkedLocations.Contains(id))
-                {
-                    return true;
-                }
-                else
-                {
-                    return false;
-                }
             }
             else
             {

--- a/Core/RandomizerBootstrap.cs
+++ b/Core/RandomizerBootstrap.cs
@@ -400,6 +400,15 @@ namespace OriBFArchipelago.Core
             fallingAction.IsTrue = false;
         }
         #endregion
+
+        #region Grove Fixes
+        private static void BootstrapSpiritTreeRefined(SceneRoot sceneRoot)
+        {
+            // Unlike most other pickups, which are permanent placeholders that spawn an object with a DestroyOnRestoreCheckpoint component,
+            // this one is *just* an object with a DestroyOnRestoreCheckpoint component. Disable that to prevent its untimely demise.
+            sceneRoot.transform.FindChild("mediumExpOrb").GetComponent<DestroyOnRestoreCheckpoint>().enabled = false;
+        }
+        #endregion
     }
 
     public class StompTriggerCondition : Condition

--- a/Core/RandomizerBootstrap.cs
+++ b/Core/RandomizerBootstrap.cs
@@ -1,27 +1,26 @@
 ﻿using Game;
 using OriModding.BF.Core;
-using OriModding.BF.l10n;
-using OriModding.BF.UiLib.Menu;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 using UnityEngine;
 
 namespace OriBFArchipelago.Core
 {
+    /**
+     * Bootstraps specific scenes to fix bugs and make randomizer changes
+     * Many changes are modified from https://github.com/ori-community/bf-rando/blob/main/Randomiser/World%20Changes/RandomiserBootstrap.cs
+     */
     internal static class RandomiserBootstrap
     {
         public static void SetupBootstrap(SceneBootstrap sceneBootstrap)
         {
             sceneBootstrap.BootstrapActions = new Dictionary<string, Action<SceneRoot>>
             {
-                // Horu
+                // Horu Fixes
                 ["mountHoruHubMid"] = BootstrapMountHoruHubMid,
 
-                // Death plane
+                // Valley Fixes
                 ["valleyOfTheWindBackground"] = BootstrapValleyOfTheWindBackground,
 
                 // Ginso Fixes
@@ -39,11 +38,26 @@ namespace OriBFArchipelago.Core
 
                 // Grotto Fixes
                 ["moonGrottoRopeBridge"] = BootstrapGrottoRopeBridge,
-                ["moonGrottoGumosHideoutB"] = BootstrapGumosHideoutB
+                ["moonGrottoGumosHideoutB"] = BootstrapGumosHideoutB,
+
+                // Grove Fixes
+                ["spiritTreeRefined"] = BootstrapSpiritTreeRefined
             };
         }
 
-        #region Horu
+        private static T InsertAction<T>(ActionSequence sequence, int index, MoonGuid guid, SceneRoot sceneRoot) where T : ActionMethod
+        {
+            var go = new GameObject();
+            go.transform.SetParent(sequence.transform);
+            var action = go.AddComponent<T>();
+            action.MoonGuid = guid;
+            action.RegisterToSaveSceneManager(sceneRoot.SaveSceneManager);
+            sequence.Actions.Insert(index, action);
+            ActionSequence.Rename(sequence.Actions);
+            return action;
+        }
+
+        #region Horu Fixes
         private static void BootstrapMountHoruHubMid(SceneRoot sceneRoot)
         {
             // Open Dungeons (remove all lava)
@@ -54,6 +68,83 @@ namespace OriBFArchipelago.Core
                 GameObject lavaStream = sceneRoot.transform.Find(lavaStreamName).gameObject;
                 lavaStream.SetActive(false);
             }
+
+            // modified from https://github.com/ori-community/bf-rando/blob/main/Randomiser/World%20Changes/RandomiserBootstrap.cs#L380
+            // credit to Vulajin for the bootstrap
+            // add randomized pickup actions for each end of room cutscene
+            Transform lavaDrainParent = sceneRoot.transform.FindChild("*doorSetups/lavaDrainSetups");
+
+            CheckLocationAction action;
+
+            // door1LavaDrain - (L3) mountHoruBreakyPathTop
+            action = InsertAction<CheckLocationAction>(lavaDrainParent.FindChild("*door1LavaDrains/*door1LavaDrain").GetComponent<ActionSequence>(), 3,
+                new MoonGuid(-300318401, 1327879929, 1546957364, -1505614911), sceneRoot);
+            action.Location = "HoruL3";
+
+            // door2LavaDrain - (R1) mountHoruStomperSystemsR
+            action = InsertAction<CheckLocationAction>(lavaDrainParent.FindChild("*door2LavaDrains/*door2LavaDrain").GetComponent<ActionSequence>(), 3,
+                new MoonGuid(-300318401, 1327879929, 1546957364, -1505614912), sceneRoot);
+            action.Location = "HoruR1";
+
+            // door3LavaDrain - (R2) mountHoruProjectileCorridor
+            action = InsertAction<CheckLocationAction>(lavaDrainParent.FindChild("*door3LavaDrains/*door3LavaDrain").GetComponent<ActionSequence>(), 3,
+                new MoonGuid(-300318401, 1327879929, 1546957364, -1505614913), sceneRoot);
+            action.Location = "HoruR2";
+
+            // door5LavaDrain - (R3) mountHoruMovingPlatform
+            action = InsertAction<CheckLocationAction>(lavaDrainParent.FindChild("*door5LavaDrains/*door5LavaDrain").GetComponent<ActionSequence>(), 3,
+                new MoonGuid(-300318401, 1327879929, 1546957364, -1505614914), sceneRoot);
+            action.Location = "HoruR3";
+
+            // door7LavaDrain - (L2) mountHoruBigPushBlock
+            action = InsertAction<CheckLocationAction>(lavaDrainParent.FindChild("*door7LavaDrains/*door7LavaDrain").GetComponent<ActionSequence>(), 3,
+                new MoonGuid(-300318401, 1327879929, 1546957364, -1505614915), sceneRoot);
+            action.Location = "HoruL2";
+
+            // door8LavaDrain - (L1) mountHoruBlockableLasers
+            action = InsertAction<CheckLocationAction>(lavaDrainParent.FindChild("*door8LavaDrains/*door8LavaDrain").GetComponent<ActionSequence>(), 3,
+                new MoonGuid(-300318401, 1327879929, 1546957364, -1505614916), sceneRoot);
+            action.Location = "HoruL1";
+
+            // special cases for L4/R4
+            CheckLocationAction leftPickupAction = lavaDrainParent.gameObject.AddComponent<CheckLocationAction>();
+            leftPickupAction.MoonGuid = new MoonGuid(-300318401, 1327879929, 1546957364, -1505614917);
+            leftPickupAction.Location = "HoruL4";
+            leftPickupAction.RegisterToSaveSceneManager(sceneRoot.SaveSceneManager);
+            CheckLocationAction rightPickupAction = lavaDrainParent.gameObject.AddComponent<CheckLocationAction>();
+            rightPickupAction.MoonGuid = new MoonGuid(-300318401, 1327879929, 1546957364, -1505614918);
+            rightPickupAction.Location = "HoruR4";
+            rightPickupAction.RegisterToSaveSceneManager(sceneRoot.SaveSceneManager);
+
+            // door4LavaDrain - L4/R4, whichever comes first
+            ActionSequence doorSequence = lavaDrainParent.FindChild("*door4LavaDrains/*door4LavaDrain").GetComponent<ActionSequence>();
+            GameObject obj = new GameObject("pickupAction");
+            obj.transform.parent = doorSequence.transform;
+
+            RunActionCondition conditionPickupAction = obj.AddComponent<RunActionCondition>();
+            conditionPickupAction.MoonGuid = new MoonGuid(-1261986975, 1336041250, 1663544246, -817715174);
+            conditionPickupAction.RegisterToSaveSceneManager(sceneRoot.SaveSceneManager);
+            conditionPickupAction.Action = leftPickupAction;
+            conditionPickupAction.ElseAction = rightPickupAction;
+            conditionPickupAction.Condition = (doorSequence.Actions[2] as RunActionCondition).Condition;
+
+            doorSequence.Actions.Insert(3, conditionPickupAction);
+            ActionSequence.Rename(doorSequence.Actions);
+
+            // door6LavaDrain - L4/R4, whichever comes second
+            doorSequence = lavaDrainParent.FindChild("*door6LavaDrains/*door6LavaDrain").GetComponent<ActionSequence>();
+            obj = new GameObject("pickupAction");
+            obj.transform.parent = doorSequence.transform;
+
+            conditionPickupAction = obj.AddComponent<RunActionCondition>();
+            conditionPickupAction.MoonGuid = new MoonGuid(-300318401, 1327879929, 1536957364, -1500614911);
+            conditionPickupAction.RegisterToSaveSceneManager(sceneRoot.SaveSceneManager);
+            conditionPickupAction.Action = rightPickupAction;
+            conditionPickupAction.ElseAction = leftPickupAction;
+            conditionPickupAction.Condition = (doorSequence.Actions[2] as RunActionCondition).Condition;
+
+            doorSequence.Actions.Insert(3, conditionPickupAction);
+            ActionSequence.Rename(doorSequence.Actions);
         }
         #endregion
 
@@ -223,18 +314,6 @@ namespace OriBFArchipelago.Core
             UnityEngine.Object.Destroy(musicZones.GetComponent<SeinWorldStateCondition>());
         }
 
-        private static T InsertAction<T>(ActionSequence sequence, int index, MoonGuid guid, SceneRoot sceneRoot) where T : ActionMethod
-        {
-            var go = new GameObject();
-            go.transform.SetParent(sequence.transform);
-            var action = go.AddComponent<T>();
-            action.MoonGuid = guid;
-            action.RegisterToSaveSceneManager(sceneRoot.SaveSceneManager);
-            sequence.Actions.Insert(index, action);
-            ActionSequence.Rename(sequence.Actions);
-            return action;
-        }
-
         #endregion
 
         #region Forlorn Fixes
@@ -309,13 +388,13 @@ namespace OriBFArchipelago.Core
             SetGrottoBridgeFallingAction fallingAction = InsertAction<SetGrottoBridgeFallingAction>(fallingSequence, 8, new MoonGuid(-1289139173, 680722594, 558787458, 1729657921), sceneRoot);
             fallingAction.IsTrue = true;
         }
-        
+
         private static void BootstrapGumosHideoutB(SceneRoot sceneRoot)
         {
             PlayerCollisionTrigger landSetupTrigger = sceneRoot.transform.Find("*landSetup/trigger").GetComponent<PlayerCollisionTrigger>();
             IsGrottoBridgeFallingCondition fallingCondition = landSetupTrigger.gameObject.AddComponent<IsGrottoBridgeFallingCondition>();
             landSetupTrigger.Condition = fallingCondition;
-            
+
             ActionSequence landSequence = sceneRoot.transform.Find("*landSetup/sequence").GetComponent<ActionSequence>();
             SetGrottoBridgeFallingAction fallingAction = InsertAction<SetGrottoBridgeFallingAction>(landSequence, 0, new MoonGuid(-1289139173, 680722594, 558787458, 1729657922), sceneRoot);
             fallingAction.IsTrue = false;
@@ -423,6 +502,16 @@ namespace OriBFArchipelago.Core
         public override bool Validate(IContext context) 
         {
             return !LocalGameState.IsTeleporting;
+        }
+    }
+
+    public class CheckLocationAction : ActionMethod
+    {
+        public string Location = "";
+
+        public override void Perform(IContext context)
+        {
+            RandomizerManager.Connection.CheckLocation(Location);
         }
     }
 }

--- a/Core/RandomizerBootstrap.cs
+++ b/Core/RandomizerBootstrap.cs
@@ -247,7 +247,7 @@ namespace OriBFArchipelago.Core
             backtrackingBlockOffTrigger.Condition = backtrackingBlockOffCondition;
 
             // For wind inside the final room
-            bool hasEscaped = RandomizerManager.Connection.IsForlornEscapeComplete();
+            bool hasEscaped = RandomizerManager.Receiver.IsLocationChecked("ForlornEscape");
             sceneRoot.transform.Find("floatZone").gameObject.SetActive(hasEscaped);
         }
 
@@ -347,7 +347,7 @@ namespace OriBFArchipelago.Core
 
         public override bool Validate(IContext context)
         {
-            return (RandomizerManager.Connection?.IsForlornEscapeComplete() ?? false) == IsTrue;
+            return (RandomizerManager.Receiver?.IsLocationChecked("ForlornEscape") ?? false) == IsTrue;
         }
     }
 

--- a/Core/RandomizerIO.cs
+++ b/Core/RandomizerIO.cs
@@ -35,14 +35,18 @@ namespace OriBFArchipelago.Core
         /**
          * Reads the save file associated with the given slot
          */
-        public static bool ReadSaveFile(int saveSlot, out RandomizerInventory inventory)
+        public static bool ReadSaveFile(int saveSlot, out RandomizerInventory inventory, out List<string> locations)
         {
+            string inventoryFileName = $"Slot{saveSlot}.txt";
+            string inventoryFullPath = $"{SAVE_FILE_PATH}\\{inventoryFileName}";
+
+            string locationFileName = $"Slot{saveSlot}Locations.txt";
+            string locationFullPath = $"{SAVE_FILE_PATH}\\{locationFileName}";
+
             try
             {
-                string fileName = $"Slot{saveSlot}.txt";
-                string fullPath = $"{SAVE_FILE_PATH}\\{fileName}";
-
-                StreamReader sr = new StreamReader(fullPath);
+                // Read inventory first
+                StreamReader sr = new StreamReader(inventoryFullPath);
 
                 // Get the version and slotname from file first
                 string version = sr.ReadLine().Split('=')[1].Trim();
@@ -57,9 +61,9 @@ namespace OriBFArchipelago.Core
 
                 foreach (string line in data)
                 {
-                    if (string.IsNullOrEmpty(line)) continue;
+                    if (string.IsNullOrEmpty(line.Trim())) continue;
 
-                    string[] pair = line.Split('=');
+                    string[] pair = line.Trim().Split('=');
 
                     if (pair.Length != 2)
                     {
@@ -79,12 +83,28 @@ namespace OriBFArchipelago.Core
                     }
                 }
 
+                // Read locations
+                sr = new StreamReader(locationFullPath);
+
+                data = sr.ReadToEnd().Split('\n');
+                sr.Close();
+
+                locations = new List<string>();
+
+                foreach (string line in data)
+                {
+                    if (string.IsNullOrEmpty(line.Trim())) continue;
+
+                    locations.Add(line.Trim());
+                }
+
                 return true;
             }
             catch (IOException e)
             {
                 Console.WriteLine($"Could not read save file: {e}");
                 inventory = new RandomizerInventory("", "");
+                locations = new List<string>();
                 return false;
             }
         }
@@ -92,13 +112,18 @@ namespace OriBFArchipelago.Core
         /** 
          * Saves the given inventory to a file
          */
-        public static bool WriteSaveFile(int saveSlot, RandomizerInventory inventory)
+        public static bool WriteSaveFile(int saveSlot, RandomizerInventory inventory, List<string> locations)
         {
+            string inventoryFileName = $"Slot{saveSlot}.txt";
+            string inventoryFullPath = $"{SAVE_FILE_PATH}\\{inventoryFileName}";
+
+            string locationFileName = $"Slot{saveSlot}Locations.txt";
+            string locationFullPath = $"{SAVE_FILE_PATH}\\{locationFileName}";
+
+            // Write inventory
             try
             {
-                string fileName = $"Slot{saveSlot}.txt";
-                string fullPath = $"{SAVE_FILE_PATH}\\{fileName}";
-
+                // Save inventory
                 StringBuilder sb = new StringBuilder();
 
                 // Save the version and slotname first
@@ -114,7 +139,21 @@ namespace OriBFArchipelago.Core
                 // remove last new line character
                 sb.Remove(sb.Length - 1, 1);
 
-                StreamWriter sw = new StreamWriter(fullPath);
+                StreamWriter sw = new StreamWriter(inventoryFullPath);
+
+                sw.Write(sb.ToString());
+
+                sw.Close();
+
+                // Save locations
+                sb = new StringBuilder();
+
+                foreach (string line in locations)
+                {
+                    sb.AppendLine(line);
+                }
+
+                sw = new StreamWriter(locationFullPath);
 
                 sw.Write(sb.ToString());
 
@@ -134,12 +173,16 @@ namespace OriBFArchipelago.Core
          */
         public static bool DeleteSaveFile(int saveSlot)
         {
-            string fileName = $"Slot{saveSlot}.txt";
-            string fullPath = $"{SAVE_FILE_PATH}\\{fileName}";
+            string inventoryFileName = $"Slot{saveSlot}.txt";
+            string inventoryFullPath = $"{SAVE_FILE_PATH}\\{inventoryFileName}";
+
+            string locationFileName = $"Slot{saveSlot}Locations.txt";
+            string locationFullPath = $"{SAVE_FILE_PATH}\\{locationFileName}";
 
             try
             {
-                File.Delete(fullPath);
+                File.Delete(inventoryFullPath);
+                File.Delete(locationFullPath);
                 return true;
             }
             catch (Exception e)

--- a/Core/RandomizerInventory.cs
+++ b/Core/RandomizerInventory.cs
@@ -79,6 +79,9 @@ namespace OriBFArchipelago.Core
         TPHoru,
         TPBlackroot,
 
+        WarmthFragment,
+        Relic,
+
         EX15,
         EX50,
         EX100,

--- a/Core/RandomizerManager.cs
+++ b/Core/RandomizerManager.cs
@@ -200,7 +200,7 @@ namespace OriBFArchipelago.Core
             inSaveSelect = true;
             connection.Disconnect();
             connection = null;
-            receiver.OnSave();
+            receiver.OnSave(true);
             receiver = null;
             LocalGameState.Reset();
         }

--- a/Core/RandomizerOptions.cs
+++ b/Core/RandomizerOptions.cs
@@ -31,7 +31,8 @@ namespace OriBFArchipelago.Core
     internal enum MapStoneOptions
     {
         Anywhere = 0,
-        AreaSpecific = 1
+        AreaSpecific = 1,
+        Progressive = 2
     }
 
     internal enum DeathLinkOptions

--- a/Core/RandomizerOptions.cs
+++ b/Core/RandomizerOptions.cs
@@ -1,11 +1,16 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 
 namespace OriBFArchipelago.Core
 {
     internal enum GoalOptions
     {
-        AllSkillTrees = 0
+        AllSkillTrees = 0,
+        AllMaps = 1,
+        WarmthFragments = 2,
+        WorldTour = 3,
+        None = 4
     }
 
     internal enum DifficultyOptions
@@ -39,6 +44,10 @@ namespace OriBFArchipelago.Core
     internal class RandomizerOptions
     {
         public GoalOptions Goal { get; }
+        public int WarmthFragmentsAvailable { get; }
+        public int WarmthFragmentsRequired { get; }
+        public int RelicCount { get; }
+        public string[] WorldTourAreas { get; }
         public DifficultyOptions LogicDifficulty { get; }
         public KeyStoneOptions KeyStoneLogic { get; }
         public MapStoneOptions MapStoneLogic { get; }
@@ -48,6 +57,10 @@ namespace OriBFArchipelago.Core
             if (apSlotData != null)
             {
                 Goal = apSlotData.TryGetValue("goal", out object goalOption) ? (GoalOptions) Enum.ToObject(typeof(GoalOptions), goalOption) : GoalOptions.AllSkillTrees;
+                WarmthFragmentsAvailable = apSlotData.TryGetValue("warmth_fragments_available", out object warmthFragmentsAvailable) ? Convert.ToInt32(warmthFragmentsAvailable) : 0;
+                WarmthFragmentsRequired = apSlotData.TryGetValue("warmth_fragments_required", out object warmthFragmentsRequired) ? Convert.ToInt32(warmthFragmentsRequired) : 0;
+                RelicCount = apSlotData.TryGetValue("relic_count", out object relicCount) ? Convert.ToInt32(relicCount) : 0;
+                WorldTourAreas = apSlotData.TryGetValue("world_tour_areas", out object worldTourAreas) ? JsonConvert.DeserializeObject<string[]>(worldTourAreas.ToString()) : [];
                 LogicDifficulty = apSlotData.TryGetValue("logic_difficulty", out object difficultyOption) ? (DifficultyOptions) Enum.ToObject(typeof(DifficultyOptions), difficultyOption) : DifficultyOptions.Casual;
                 KeyStoneLogic = apSlotData.TryGetValue("keystone_logic", out object keystoneOption) ? (KeyStoneOptions) Enum.ToObject(typeof(KeyStoneOptions), keystoneOption) : KeyStoneOptions.Anywhere;
                 MapStoneLogic = apSlotData.TryGetValue("mapstone_logic", out object mapstoneOption) ? (MapStoneOptions) Enum.ToObject(typeof(MapStoneOptions), mapstoneOption) : MapStoneOptions.Anywhere;
@@ -56,6 +69,10 @@ namespace OriBFArchipelago.Core
             else
             {
                 Goal = GoalOptions.AllSkillTrees;
+                WarmthFragmentsAvailable = 0;
+                WarmthFragmentsRequired = 0;
+                RelicCount = 0;
+                WorldTourAreas = [];
                 LogicDifficulty = DifficultyOptions.Casual;
                 KeyStoneLogic = KeyStoneOptions.Anywhere;
                 MapStoneLogic = MapStoneOptions.Anywhere;

--- a/Core/RandomizerReceiver.cs
+++ b/Core/RandomizerReceiver.cs
@@ -218,15 +218,19 @@ namespace OriBFArchipelago.Core
         /**
          * Called when the player reaches/creates a checkpoint and saves the game
          */
-        public void OnSave()
+        public void OnSave(bool isQuitting = false)
         {
             Console.WriteLine("Saving...");
 
             // Add used items to saved inventory and reset to start tracking again
-            savedInventory.AddAll(unsavedInventory);
-            onLoadInventory.AddAll(unsavedInventory);
-            unsavedInventory.Reset();
-
+            // Only do this when the player manually saves, not when the player quits
+            if (!isQuitting)
+            {
+                savedInventory.AddAll(unsavedInventory);
+                onLoadInventory.AddAll(unsavedInventory);
+                unsavedInventory.Reset();
+            }
+            
             RandomizerIO.WriteSaveFile(saveSlot, savedInventory);
             Resync();
         }

--- a/Core/RandomizerReceiver.cs
+++ b/Core/RandomizerReceiver.cs
@@ -27,6 +27,12 @@ namespace OriBFArchipelago.Core
         // compares against savedInventory to make sure items aren't duplicated
         private RandomizerInventory onLoadInventory;
 
+        // locally saves the locaiotns that have been checked in game
+        private List<string> checkedLocations;
+
+        // similar purpose to unsavedInventory
+        private List<string> unsavedCheckedLocations;
+
         // the number of the associated save slot in Ori
         private int saveSlot;
 
@@ -58,12 +64,14 @@ namespace OriBFArchipelago.Core
 
             onLoadInventory = new RandomizerInventory(VERSION, apSlotName);
             unsavedInventory = new RandomizerInventory(VERSION, apSlotName);
+            unsavedCheckedLocations = new List<string>();
 
             if (isNew)
             {
                 // If this is a new slot, create a new inventory
                 savedInventory = new RandomizerInventory(VERSION, apSlotName);
-                if (RandomizerIO.WriteSaveFile(saveSlot, savedInventory))
+                checkedLocations = new List<string>();
+                if (RandomizerIO.WriteSaveFile(saveSlot, savedInventory, checkedLocations))
                 {
                     Console.Write($"Successfully created new inventory for slot {saveSlot}");
                 }
@@ -75,7 +83,7 @@ namespace OriBFArchipelago.Core
             else
             {
                 // Otherwise, load the inventory from file
-                if (RandomizerIO.ReadSaveFile(saveSlot, out savedInventory))
+                if (RandomizerIO.ReadSaveFile(saveSlot, out savedInventory, out checkedLocations))
                 {
                     Console.Write($"Successfully loaded inventory from slot {saveSlot}");
                 }
@@ -204,6 +212,22 @@ namespace OriBFArchipelago.Core
         }
 
         /**
+         * Called when the player checks a location locally. Used for tracking pruposes
+         */
+        public void CheckLocation(string location)
+        {
+            unsavedCheckedLocations.Add(location);
+        }
+
+        /**
+         * Checks if a location has been locally reached
+         */
+        public bool IsLocationChecked(string location)
+        {
+            return checkedLocations.Contains(location) || unsavedCheckedLocations.Contains(location);
+        }
+
+        /**
          * Called when the player dies
          */
         public void OnDeath()
@@ -211,8 +235,9 @@ namespace OriBFArchipelago.Core
             // Resync items to bypass the death rollback
             Resync();
 
-            // Remove any tracking of used items
+            // Remove any tracking of used items and checked locations
             unsavedInventory.Reset();
+            unsavedCheckedLocations.Clear();
         }
 
         /**
@@ -229,9 +254,12 @@ namespace OriBFArchipelago.Core
                 savedInventory.AddAll(unsavedInventory);
                 onLoadInventory.AddAll(unsavedInventory);
                 unsavedInventory.Reset();
+
+                checkedLocations.AddRange(unsavedCheckedLocations);
+                unsavedCheckedLocations.Clear();
             }
             
-            RandomizerIO.WriteSaveFile(saveSlot, savedInventory);
+            RandomizerIO.WriteSaveFile(saveSlot, savedInventory, checkedLocations);
             Resync();
         }
 

--- a/OriBFArchipelago.csproj
+++ b/OriBFArchipelago.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>OriBFArchipelago</AssemblyName>
     <Description>Archipelago client for Ori and the Blind Forest</Description>
-    <Version>0.2.4</Version>
+    <Version>0.3.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/Patches/TeleporterControllerPatch.cs
+++ b/Patches/TeleporterControllerPatch.cs
@@ -16,6 +16,9 @@ namespace OriBFArchipelago.Patches
         [HarmonyPostfix, HarmonyPatch(nameof(TeleporterController.OnFadedToBlack))]
         private static void OnFadedToBlackPostfix()
         {
+            // save the game on teleporting
+            GameController.Instance.SaveGameController.PerformSave();
+
             // Reset misty woods
             var mistyEvents = WorldEventsHelper.MistyWorldEvents;
             int value = mistyEvents?.Value ?? 10;


### PR DESCRIPTION
Additions
- Goal Modes
  - *All goal modes are requirements to unlock the final escape in Mount Horu*
  - All Skill Trees: now includes picking up Kuro's Feather / Glide
  - All Maps: place all mapstones around Nibel
  - Warmth Fragments: collect the required amount of warmth fragments. Number of warmth fragments required/available is configurable
  - World Tour: collect all relics from around Nibel. A configurable number of areas will be chosen to hold a relic in a random location within that area
  - None: no other requirements
- Horu lava room locations. These can be obtained by stopping the flow of lava in each of the eight Horu rooms. For purposes of hinting, these locations are named `HoruL1`, `HoruL2`, `HoruL3`, `HoruL4`, `HoruR1`, `HoruR2`, `HoruR3`, and `HoruR4`
- New Mapstone Logic option: Progressive Mapstones. Locations are based on how many mapstones have been placed instead of specific mapstone locations. E.g. the first mapstone placed will always send `ProgressiveMap1` and the last will send `ProgressiveMap9`

Fixes
- Fixed issues with losing/duplicating keystones and mapstones when teleporting and/or quitting to main menu
- All Skill Trees (and All Maps) goal will be no longer be affected by `!collect` commands run by other worlds
- Fix disappearing exp orb near the spirit tree