### PR TITLE
Cleanup location tracking

### DIFF
--- a/Core/ArchipelagoConnection.cs
+++ b/Core/ArchipelagoConnection.cs
@@ -23,6 +23,7 @@ namespace OriBFArchipelago.Core
         public const string GAME_NAME = "Ori and the Blind Forest";
         public const string MAP_LOCATION_DATA_KEY = "MapLocations";
         public const string FOUND_RELICS_DATA_KEY = "FoundRelics";
+        public const string POSITION_DATA_KEY = "Position";
 
         // The archipelago session
         private ArchipelagoSession session;
@@ -31,6 +32,10 @@ namespace OriBFArchipelago.Core
         private int port;
         private string slotName;
         private string password;
+
+        // Position update variables
+        private float positionTimer = 0;
+        private const float POSITION_UPDATE_RATE = 5; // every 5 seconds
 
         // boolean used to ignore the death caused by deathlink as to not send another
         private bool ignoreNextDeath;
@@ -128,6 +133,7 @@ namespace OriBFArchipelago.Core
 
                 session.DataStorage[Scope.Slot, MAP_LOCATION_DATA_KEY].Initialize(new string[0]);
                 session.DataStorage[Scope.Slot, FOUND_RELICS_DATA_KEY].Initialize(new string[0]);
+                session.DataStorage[Scope.Slot, POSITION_DATA_KEY].Initialize(new float[0]);
 
                 RecheckLocations();
                 UpdateMapLocations();
@@ -153,6 +159,26 @@ namespace OriBFArchipelago.Core
                 Damage damage = new Damage(10000f, Vector2.zero, Vector2.zero, DamageType.Lava, Characters.Sein.gameObject);
                 Characters.Sein.Controller.OnRecieveDamage(damage);
             }
+
+            // Update position every POSITION_UPDATE_RATE seconds
+            positionTimer += Time.deltaTime;
+            if (positionTimer >= POSITION_UPDATE_RATE)
+            {
+                positionTimer = 0;
+                UpdatePositionTracking();
+            }
+        }
+
+        /**
+         * Updates the player's current player position to the AP server
+         */
+        private void UpdatePositionTracking()
+        {
+            float x = Characters.Sein.transform.position.x;
+            float y = Characters.Sein.transform.position.y;
+            float[] position = [x, y];
+
+            session.DataStorage[Scope.Slot, POSITION_DATA_KEY] = position;
         }
 
         /**

--- a/Core/ArchipelagoConnection.cs
+++ b/Core/ArchipelagoConnection.cs
@@ -176,7 +176,7 @@ namespace OriBFArchipelago.Core
         /**
          * Send a message to the server that a location has been checked
          */
-        public async void CheckLocation(string location)
+        public async void CheckLocation(Location location)
         {
             if (location is null)
             {
@@ -187,16 +187,16 @@ namespace OriBFArchipelago.Core
             if (Connected)
             {
                 if (RandomizerManager.Options.MapStoneLogic == MapStoneOptions.Progressive &&
-                    mapLocations.Contains(location))
+                    mapLocations.Contains(location.Name))
                 {
                     // track the original location in addition to the progressive location
-                    RandomizerManager.Receiver.CheckLocation(location);
+                    RandomizerManager.Receiver.CheckLocation(location.Name);
 
                     int nextMap = RandomizerManager.Receiver.GetItemCount(InventoryItem.MapStoneUsed);
-                    location = "ProgressiveMap" + nextMap;
+                    location = LocationLookup.Get("ProgressiveMap" + nextMap);
                 }
 
-                long locationId = session.Locations.GetLocationIdFromName(GAME_NAME, location);
+                long locationId = session.Locations.GetLocationIdFromName(GAME_NAME, location.Name);
                 await Task.Factory.StartNew(() => session.Locations.CompleteLocationChecks(locationId));
                 Console.WriteLine("Checked " + location);
             }
@@ -205,15 +205,23 @@ namespace OriBFArchipelago.Core
                 Console.WriteLine("Checked " + location + " but not connected");
             }
 
-            RandomizerManager.Receiver.CheckLocation(location);
+            RandomizerManager.Receiver.CheckLocation(location.Name);
         }
 
         /**
-         * Check location using gameobject location lookup
+         * Check location using MoonGuid
          */
-        public void CheckLocationByGameObject(GameObject g)
+        public void CheckLocation(MoonGuid guid)
         {
-            CheckLocation(LocationLookup.GetLocationName(g));
+            CheckLocation(LocationLookup.Get(guid));
+        }
+
+        /**
+         * Check location using name
+         */
+        public void CheckLocation(string name)
+        {
+            CheckLocation(LocationLookup.Get(name));
         }
 
         /**
@@ -365,15 +373,15 @@ namespace OriBFArchipelago.Core
                 {
                     int collectedRelics = RandomizerManager.Receiver.GetItemCount(InventoryItem.Relic);
                     int requiredRelics = RandomizerManager.Options.RelicCount;
-                    string[] relicAreas = RandomizerManager.Options.WorldTourAreas;
+                    WorldArea[] relicAreas = RandomizerManager.Options.WorldTourAreas;
                     hasMetGoal = collectedRelics >= requiredRelics;
                     message.Append($"Collected {collectedRelics} out of {requiredRelics} relics. \n");
                     if (!hasMetGoal)
                     {
                         message.Append($"Relics can be found in ");
-                        foreach (string relic in relicAreas)
+                        foreach (WorldArea area in relicAreas)
                         {
-                            message.Append(relic).Append(", ");
+                            message.Append(area).Append(", ");
                         }
                         message.Remove(message.Length - 2, 2); // remove last comma
                     }

--- a/Core/Keybinder.cs
+++ b/Core/Keybinder.cs
@@ -29,7 +29,8 @@ namespace OriBFArchipelago.Core
         DoubleBash,
         GrenadeJump,
         ListStones,
-        GoalProgress
+        GoalProgress,
+        Reconnect
     }
 
     /**
@@ -70,7 +71,8 @@ namespace OriBFArchipelago.Core
             { KeybindAction.DoubleBash, "Grenade" },
             { KeybindAction.GrenadeJump, "Grenade+Jump" },
             { KeybindAction.ListStones, "LeftAlt+S, RightAlt+S" },
-            { KeybindAction.GoalProgress, "LeftAlt+G, RightAlt+G" }
+            { KeybindAction.GoalProgress, "LeftAlt+G, RightAlt+G" },
+            { KeybindAction.Reconnect, "LeftAlt+K, RightAlt+K" }
         };
 
         /**
@@ -362,6 +364,9 @@ namespace OriBFArchipelago.Core
             if (RandomizerIO.ReadKeybinds(out fileKeybinds))
             {
                 keybinds = parseBindSets(fileKeybinds);
+
+                // Write to file to fill in any missing keybinds, such as new defaults from updates
+                RandomizerIO.WriteKeybinds(keybinds.ToDictionary(x => x.Key, x => x.Value.ToString())); 
             }
             else
             {

--- a/Core/LocationLookup.cs
+++ b/Core/LocationLookup.cs
@@ -80,6 +80,12 @@ namespace OriBFArchipelago.Core
             if (moonGuid == null) return null;
 
             locationByGuid.TryGetValue(moonGuid, out Location target);
+
+            if (target == null)
+            {
+                Console.WriteLine("Invalid location: " + moonGuid.ToString());
+            }
+
             return target;
         }
 
@@ -99,6 +105,12 @@ namespace OriBFArchipelago.Core
             if (name == null) return null;
 
             locationByName.TryGetValue(name, out Location target);
+
+            if (target == null)
+            {
+                Console.WriteLine("Invalid location: " + name);
+            }
+
             return target;
         }
 

--- a/Core/LocationLookup.cs
+++ b/Core/LocationLookup.cs
@@ -6,348 +6,371 @@ using UnityEngine;
 
 namespace OriBFArchipelago.Core
 {
+    internal enum LocationType
+    {
+        EnergyCell,
+        HealthCell,
+        AbilityCell,
+        Skill,
+        Keystone,
+        Mapstone,
+        Map,
+        Plant,
+        Event,
+        Cutscene,
+        ExpSmall,
+        ExpMedium,
+        ExpLarge,
+        ProgressiveMap
+    }
+
+    internal class Location
+    {
+        public MoonGuid MoonGuid { get; private set; }
+        public string Name { get; private set; }
+        public WorldArea Area { get; private set; }
+        public LocationType Type { get; private set; }
+        public Vector2 WorldPosition { get; private set; }
+
+        public Location(MoonGuid moonGuid, string name, WorldArea area, LocationType type, Vector2 worldPosition)
+        {
+            MoonGuid = moonGuid;
+            Name = name;
+            Area = area;
+            Type = type;
+            WorldPosition = worldPosition;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || GetType() != obj.GetType())
+            {
+                return false;
+            }
+
+            return MoonGuid.Equals((obj as Location)?.MoonGuid);
+        }
+
+        public override int GetHashCode()
+        {
+            return MoonGuid.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            return Name;
+        }
+    }
+
     internal class LocationLookup
     {
-        internal struct Position
+        public static Location Get(MoonGuid moonGuid)
         {
-            public double x;
-            public double y;
-
-            public Position()
+            // If this is the first time this is called, populate the locationByGuid dictionary
+            if (locationByGuid is null)
             {
-                x = 0; y = 0;
+                locationByGuid = new Dictionary<MoonGuid, Location>();
+
+                foreach (Location location in locations)
+                {
+                    locationByGuid.Add(location.MoonGuid, location);
+                }
             }
 
-            public Position(double x, double y)
-            {
-                this.x = x;
-                this.y = y;
-            }
+            if (moonGuid == null) return null;
 
-            public double DistanceSquared(Position other)
-            {
-                double diffX = other.x - x, diffY = other.y - y;
-                return diffX * diffX + diffY * diffY;
-            }
-
-            public override bool Equals(object obj)
-            {
-                return obj is Position position &&
-                       x == position.x &&
-                       y == position.y;
-            }
-
-            public override int GetHashCode()
-            {
-                int hashCode = 1502939027;
-                hashCode = hashCode * -1521134295 + x.GetHashCode();
-                hashCode = hashCode * -1521134295 + y.GetHashCode();
-                return hashCode;
-            }
-
-            public override string ToString()
-            {
-                return "(" + x + ", " + y + ")";
-            }
+            locationByGuid.TryGetValue(moonGuid, out Location target);
+            return target;
         }
 
-        private const double THRESHOLD = 400;
-
-        public static string GetLocationName(GameObject g)
+        public static Location Get(string name)
         {
-            Position p = new Position();
-            p.x = Mathf.Round(g.transform.position.x * 10) / 10.0;
-            p.y = Mathf.Round(g.transform.position.y * 10) / 10.0;
-
-            if (locations.ContainsKey(p))
+            // If this is the first time this is called, populate the locationByName dictionary
+            if (locationByName is null)
             {
-                return locations[p];
-            }
-            else
-            {
-                // unfortunately, the location may not be exact, so go through the list and find the closest location
-                Position closest = new Position();
-                double minDistance = 999;
-                foreach (var location in locations)
-                {
-                    double distance = p.DistanceSquared(location.Key);
-                    if (distance < minDistance)
-                    {
-                        minDistance = distance;
-                        closest = location.Key;
-                    }
-                }
+                locationByName = new Dictionary<string, Location>();
 
-                if (locations.ContainsKey(closest) && minDistance < THRESHOLD)
+                foreach (Location location in locations)
                 {
-                    return locations[closest];
-                }
-                else
-                {
-                    Console.WriteLine("No location at " + p.ToString());
-                    return null;
+                    locationByName.Add(location.Name, location);
                 }
             }
+
+            if (name == null) return null;
+
+            locationByName.TryGetValue(name, out Location target);
+            return target;
         }
 
-        private static readonly Dictionary<Position, string> locations = new Dictionary<Position, string>
+        private static Dictionary<string, Location> locationByName;
+
+        private static Dictionary<MoonGuid, Location> locationByGuid;
+
+        private static readonly List<Location> locations = new List<Location>()
         {
-            { new Position(92.0, -227.5), "FirstPickup" },
-            { new Position(-27.4, -256.3), "FirstEnergyCell" },
-            { new Position(-154.5, -271.8), "FronkeyFight" },
-            { new Position(83.1, -222.3), "GladesKeystone1" },
-            { new Position(-11.1, -206.4), "GladesKeystone2" },
-            { new Position(59.0, -280.9), "GladesGrenadePool" },
-            { new Position(83.0, -196.8), "GladesGrenadeTree" },
-            { new Position(5.7, -241.8), "GladesMainPool" },
-            { new Position(-40.1, -239.8), "GladesMainPoolDeep" },
-            { new Position(257.1, -199.7), "FronkeyWalkRoof" },
-            { new Position(-80.5, -189.0), "FourthHealthCell" },
-            { new Position(-59.4, -244.3), "GladesMapKeystone" },
-            { new Position(-316.0, -308.0), "WallJumpSkillTree" },
-            { new Position(-283.4, -236.4), "LeftGladesHiddenExp" },
-            { new Position(303.4, -190.5), "DeathGauntletExp" },
-            { new Position(423.8, -169.2), "DeathGauntletEnergyCell" },
-            { new Position(-81.0, -248.0), "GladesMap" },
-            { new Position(-48.3, -166.0), "AboveFourthHealth" },
-            { new Position(-245.7, -277.0), "WallJumpAreaExp" },
-            { new Position(-336.8, -288.2), "WallJumpAreaEnergyCell" },
-            { new Position(-247.1, -207.1), "LeftGladesExp" },
-            { new Position(-238.3, -212.4), "LeftGladesKeystone" },
-            { new Position(-184.9, -227.6), "LeftGladesMapstone" },
-            { new Position(-182.1, -194.0), "SpiritCavernsKeystone1" },
-            { new Position(-217.4, -183.9), "SpiritCavernsKeystone2" },
-            { new Position(-177.9, -154.5), "SpiritCavernsTopRightKeystone" },
-            { new Position(-217.5, -146.3), "SpiritCavernsTopLeftKeystone" },
-            { new Position(-216.4, -176.4), "SpiritCavernsAbilityCell" },
-            { new Position(-155.0, -186.0), "GladesLaser" },
-            { new Position(-165.4, -140.4), "GladesLaserGrenade" },
-            { new Position(-56.0, -160.0), "ChargeFlameSkillTree" },
-            { new Position(43.0, -156.0), "ChargeFlameAreaPlant" },
-            { new Position(5.0, -193.2), "ChargeFlameAreaExp" },
-            { new Position(-14.2, -95.7), "AboveChargeFlameTreeExp" },
-            { new Position(64.0, -109.4), "SpiderSacEnergyDoor" },
-            { new Position(151.8, -117.8), "SpiderSacHealthCell" },
-            { new Position(60.7, -155.8), "SpiderSacEnergyCell" },
-            { new Position(93.4, -92.5), "SpiderSacGrenadeDoor" },
-            { new Position(154.0, -291.5), "DashAreaOrbRoomExp" },
-            { new Position(183.8, -291.5), "DashAreaAbilityCell" },
-            { new Position(197.3, -229.1), "DashAreaRoofExp" },
-            { new Position(292.0, -256.0), "DashSkillTree" },
-            { new Position(313.0, -232.0), "DashAreaPlant" },
-            { new Position(304.4, -303.2), "RazielNo" },
-            { new Position(346.0, -255.0), "DashAreaMapstone" },
-            { new Position(395.0, -309.1), "BlackrootTeleporterHealthCell" },
-            { new Position(418.0, -291.0), "BlackrootMap" },
-            { new Position(432.0, -324.0), "BlackrootBoulderExp" },
-            { new Position(72.0, -380.0), "GrenadeSkillTree" },
-            { new Position(224.0, -359.1), "GrenadeAreaExp" },
-            { new Position(252.4, -331.9), "GrenadeAreaAbilityCell" },
-            { new Position(279.0, -375.0), "LowerBlackrootAbilityCell" },
-            { new Position(391.5, -423.0), "LowerBlackrootLaserAbilityCell" },
-            { new Position(339.0, -418.8), "LowerBlackrootLaserExp" },
-            { new Position(208.5, -431.5), "LowerBlackrootGrenadeThrow" },
-            { new Position(459.5, -506.8), "LostGroveAbilityCell" },
-            { new Position(462.4, -489.5), "LostGroveHiddenExp" },
-            { new Position(307.3, -525.2), "LostGroveTeleporter" },
-            { new Position(527.0, -544.0), "LostGroveLongSwim" },
-            { new Position(300.0, -94.0), "HollowGroveMapstone" },
-            { new Position(703.2, -82.3), "OuterSwampAbilityCell" },
-            { new Position(618.5, -98.0), "OuterSwampStompExp" },
-            { new Position(581.5, -67.0), "OuterSwampHealthCell" },
-            { new Position(351.0, -119.0), "HollowGroveMap" },
-            { new Position(333.1, -61.9), "HollowGroveTreeAbilityCell" },
-            { new Position(365.0, -119.0), "HollowGroveMapPlant" },
-            { new Position(330.0, -78.0), "HollowGroveTreePlant" },
-            { new Position(628.0, -120.0), "SwampEntrancePlant" },
-            { new Position(435.0, -140.0), "MoonGrottoStompPlant" },
-            { new Position(515.0, -100.0), "OuterSwampMortarPlant" },
-            { new Position(354.0, -178.5), "GroveWaterStompAbilityCell" },
-            { new Position(666.0, -48.0), "OuterSwampGrenadeExp" },
-            { new Position(409.5, -34.5), "SwampTeleporterAbilityCell" },
-            { new Position(174.2, -105.6), "GroveAboveSpiderWaterExp" },
-            { new Position(261.4, -117.7), "GroveAboveSpiderWaterHealthCell" },
-            { new Position(272.5, -97.5), "GroveAboveSpiderWaterEnergyCell" },
-            { new Position(187.3, -163.9), "GroveSpiderWaterSwim" },
-            { new Position(339.0, -216.0), "DeathGauntletSwimEnergyDoor" },
-            { new Position(356.8, -207.1), "DeathGauntletStompSwim" },
-            { new Position(477.0, -140.0), "AboveGrottoTeleporterExp" },
-            { new Position(432.0, -108.0), "GrottoLasersRoofExp" },
-            { new Position(365.2, -109.1), "IcelessExp" },
-            { new Position(540.0, -220.0), "BelowGrottoTeleporterPlant" },
-            { new Position(450.0, -166.8), "LeftGrottoTeleporterExp" },
-            { new Position(502.0, -108.0), "OuterSwampMortarAbilityCell" },
-            { new Position(595.0, -136.0), "SwampEntranceSwim" },
-            { new Position(543.6, -189.4), "BelowGrottoTeleporterHealthCell" },
-            { new Position(423.0, -274.0), "GrottoEnergyDoorSwim" },
-            { new Position(424.0, -220.0), "GrottoEnergyDoorHealthCell" },
-            { new Position(552.0, -141.5), "GrottoSwampDrainAccessExp" },
-            { new Position(537.0, -176.0), "GrottoSwampDrainAccessPlant" },
-            { new Position(451.0, -296.0), "GrottoHideoutFallAbilityCell" },
-            { new Position(513.0, -413.0), "GumoHideoutMapstone" },
-            { new Position(620.0, -404.0), "GumoHideoutMiniboss" },
-            { new Position(572.5, -378.5), "GumoHideoutCrusherExp" },
-            { new Position(590.0, -384.0), "GumoHideoutCrusherKeystone" },
-            { new Position(496.0, -369.0), "GumoHideoutRightHangingExp" },
-            { new Position(467.5, -369.0), "GumoHideoutLeftHangingExp" },
-            { new Position(449.0, -430.0), "GumoHideoutRedirectAbilityCell" },
-            { new Position(477.0, -389.0), "GumoHideoutMap" }, //No location at (477, -388.2)
-            { new Position(784.0, -412.0), "DoubleJumpSkillTree" },
-            { new Position(759.0, -398.0), "DoubleJumpAreaExp" },
-            { new Position(545.8, -357.9), "GumoHideoutEnergyCell" },
-            { new Position(567.6, -246.2), "GumoHideoutRockfallExp" },
-            { new Position(500.0, -248.0), "WaterVein" },
-            { new Position(406.9, -386.2), "LeftGumoHideoutExp" },
-            { new Position(393.8, -375.6), "LeftGumoHideoutHealthCell" },
-            { new Position(447.0, -368.0), "LeftGumoHideoutLowerPlant" },
-            { new Position(439.0, -344.0), "LeftGumoHideoutUpperPlant" },
-            { new Position(492.0, -400.0), "GumoHideoutRedirectPlant" },
-            { new Position(397.0, -411.5), "LeftGumoHideoutSwim" },
-            { new Position(515.4, -441.9), "GumoHideoutRedirectEnergyCell" },
-            { new Position(505.3, -439.4), "GumoHideoutRedirectExp" },
-            { new Position(328.9, -353.7), "FarLeftGumoHideoutExp" },
-            { new Position(643.5, -127.5), "SwampEntranceAbilityCell" },
-            { new Position(321.7, -179.1), "DeathGauntletRoofHealthCell" },
-            { new Position(342.0, -179.0), "DeathGauntletRoofPlant" },
-            { new Position(523.0, 142.0), "LowerGinsoHiddenExp" },
-            { new Position(531.0, 267.0), "LowerGinsoKeystone1" },
-            { new Position(540.0, 277.0), "LowerGinsoKeystone2" },
-            { new Position(508.0, 304.0), "LowerGinsoKeystone3" },
-            { new Position(529.0, 297.0), "LowerGinsoKeystone4" },
-            { new Position(540.0, 101.0), "LowerGinsoPlant" },
-            { new Position(532.0, 328.0), "BashSkillTree" },
-            { new Position(518.4, 339.8), "BashAreaExp" },
-            { new Position(507.0, 476.0), "UpperGinsoLowerKeystone" },
-            { new Position(535.0, 488.0), "UpperGinsoRightKeystone" },
-            { new Position(531.0, 502.0), "UpperGinsoUpperRightKeystone" },
-            { new Position(508.0, 498.0), "UpperGinsoUpperLeftKeystone" },
-            { new Position(517.1, 384.4), "UpperGinsoRedirectLowerExp" },
-            { new Position(530.5, 407.0), "UpperGinsoRedirectUpperExp" },
-            { new Position(536.6, 434.7), "UpperGinsoEnergyCell" },
-            { new Position(456.9, 566.1), "TopGinsoLeftLowerExp" },
-            { new Position(471.2, 614.8), "TopGinsoLeftUpperExp" },
-            { new Position(610.0, 611.0), "TopGinsoRightPlant" },
-            { new Position(534.5, 661.5), "GinsoEscapeSpiderExp" },
-            { new Position(537.5, 733.6), "GinsoEscapeJumpPadExp" },
-            { new Position(533.5, 827.3), "GinsoEscapeProjectileExp" },
-            { new Position(519.3, 867.6), "GinsoEscapeHangingExp" },
-            { new Position(548.0, 952.0), "GinsoEscapeExit" },
-            { new Position(677.0, -129.0), "SwampMap" },
-            { new Position(637.0, -162.2), "InnerSwampDrainExp" },
-            { new Position(761.9, -173.5), "InnerSwampHiddenSwimExp" },
-            { new Position(684.0, -205.0), "InnerSwampSwimLeftKeystone" },
-            { new Position(766.0, -183.0), "InnerSwampSwimRightKeystone" },
-            { new Position(796.0, -210.0), "InnerSwampSwimMapstone" },
-            { new Position(770.9, -148.0), "InnerSwampStompExp" },
-            { new Position(722.3, -95.5), "InnerSwampEnergyCell" },
-            { new Position(860.0, -96.0), "StompSkillTree" },
-            { new Position(914.9, -71.3), "StompAreaRoofExp" },
-            { new Position(884.0, -98.3), "StompAreaExp" },
-            { new Position(874.2, -143.6), "StompAreaGrenadeExp" },
-            { new Position(97.5, -37.9), "HoruFieldsHiddenExp" },
-            { new Position(175.9, 1.0), "HoruFieldsEnergyCell" },
-            { new Position(124.0, 21.0), "HoruFieldsPlant" },
-            { new Position(176.8, -34.6), "HoruFieldsAbilityCell" },
-            { new Position(160.3, -78.4), "HoruFieldsHealthCell" },
-            { new Position(56.0, 343.0), "HoruMap" },
-            { new Position(-29.8, 148.9), "HoruL4LowerExp" },
-            { new Position(-191.7, 194.4), "HoruL4ChaseExp" },
-            { new Position(13.5, 164.3), "HoruLavaDrainedLeftExp" },
-            { new Position(193.8, 384.9), "HoruR1HangingExp" },
-            { new Position(148.0, 363.0), "HoruR1Mapstone" },
-            { new Position(249.4, 403.0), "HoruR1EnergyCell" },
-            { new Position(318.0, 245.0), "HoruR3Plant" },
-            { new Position(191.7, 165.2), "HoruR4StompExp" },
-            { new Position(253.5, 194.6), "HoruR4LaserExp" },
-            { new Position(163.4, 136.4), "HoruR4DrainedExp" },
-            { new Position(129.8, 165.6), "HoruLavaDrainedRightExp" },
-            { new Position(106.5, 112.0), "DoorWarpExp" },
-            { new Position(98.0, 130.5), "HoruTeleporterExp" },
-            { new Position(264.0, 380.0), "HoruR1" },
-            { new Position(172.0, 288.0), "HoruR2" },
-            { new Position(304.0, 304.0), "HoruR3" },
-            { new Position(216.0, 192.0), "HoruR4" },
-            { new Position(-92.0, 376.0), "HoruL1" },
-            { new Position(-20.0, 276.0), "HoruL2" },
-            { new Position(-164.0, 336.0), "HoruL3" },
-            { new Position(-96.0, 152.0), "HoruL4" },
-            { new Position(-206.0, -113.3), "ValleyEntryAbilityCell" },
-            { new Position(-221.0, -84.0), "ValleyEntryTreeExp" },
-            { new Position(-179.0, -88.0), "ValleyEntryTreePlant" },
-            { new Position(-320.0, -162.0), "ValleyEntryGrenadeLongSwim" },
-            { new Position(-355.4, 65.6), "ValleyRightFastStomplessCell" },
-            { new Position(-418.8, 67.5), "ValleyRightExp" },
-            { new Position(-292.0, 20.7), "ValleyRightBirdStompCell" },
-            { new Position(-460.0, -13.0), "GlideSkillFeather" },
-            { new Position(-546.2, 54.4), "KuroPerchExp" },
-            { new Position(-408.0, -170.0), "ValleyMap" },
-            { new Position(-468.0, -67.0), "ValleyMainPlant" },
-            { new Position(-572.0, 157.0), "WilhelmExp" },
-            { new Position(-359.0, -87.5), "ValleyRightSwimExp" },
-            { new Position(-415.5, -80.0), "ValleyMainFACS" },
-            { new Position(-460.0, -187.0), "ValleyForlornApproachGrenade" },
-            { new Position(-350.9, -98.7), "ValleyThreeBirdAbilityCell" },
-            { new Position(-561.0, -89.0), "LowerValleyMapstone" },
-            { new Position(-538.0, -104.0), "LowerValleyExp" },
-            { new Position(-460.0, -255.0), "OutsideForlornTreeExp" },
-            { new Position(-514.5, -277.3), "OutsideForlornWaterExp" },
-            { new Position(-538.7, -234.7), "OutsideForlornCliffExp" },
-            { new Position(-443.0, -152.0), "ValleyForlornApproachMapstone" },
-            { new Position(-703.9, -390.0), "ForlornEntranceExp" },
-            { new Position(-841.3, -350.9), "ForlornHiddenSpiderExp" },
-            { new Position(-858.0, -353.0), "ForlornKeystone1" },
-            { new Position(-892.0, -328.0), "ForlornKeystone2" },
-            { new Position(-888.0, -251.0), "ForlornKeystone3" },
-            { new Position(-869.0, -255.0), "ForlornKeystone4" },
-            { new Position(-843.0, -308.0), "ForlornMap" },
-            { new Position(-815.0, -266.0), "ForlornPlant" },
-            { new Position(-625.5, -315.1), "RightForlornHealthCell" },
-            { new Position(-732.0, -236.0), "ForlornEscape" },
-            { new Position(-607.0, -314.0), "RightForlornPlant" },
-            { new Position(-510.3, 204.3), "SorrowEntranceAbilityCell" },
-            { new Position(-485.0, 323.0), "SorrowMainShaftKeystone" },
-            { new Position(-503.0, 274.0), "SorrowSpikeKeystone" },
-            { new Position(-514.0, 303.0), "SorrowHiddenKeystone" },
-            { new Position(-596.0, 229.0), "SorrowLowerLeftKeystone" },
-            { new Position(-451.0, 284.0), "SorrowMap" },
-            { new Position(-435.0, 322.0), "SorrowMapstone" },
-            { new Position(-609.0, 299.0), "SorrowHealthCell" },
-            { new Position(-671.1, 290.0), "LeftSorrowAbilityCell" },
-            { new Position(-608.0, 329.0), "LeftSorrowKeystone1" },
-            { new Position(-612.0, 347.0), "LeftSorrowKeystone2" },
-            { new Position(-604.0, 361.0), "LeftSorrowKeystone3" },
-            { new Position(-613.1, 371.7), "LeftSorrowKeystone4" },
-            { new Position(-627.1, 394.0), "LeftSorrowEnergyCell" },
-            { new Position(-630.0, 249.0), "LeftSorrowPlant" },
-            { new Position(-677.0, 269.9), "LeftSorrowGrenade" },
-            { new Position(-456.0, 419.0), "UpperSorrowRightKeystone" },
-            { new Position(-414.0, 429.0), "UpperSorrowFarRightKeystone" },
-            { new Position(-514.0, 427.0), "UpperSorrowLeftKeystone" },
-            { new Position(-545.0, 409.5), "UpperSorrowSpikeExp" },
-            { new Position(-592.0, 445.0), "UpperSorrowFarLeftKeystone" },
-            { new Position(-696.0, 408.0), "ChargeJumpSkillTree" },
-            { new Position(-646.9, 473.1), "AboveChargeJumpAbilityCell" },
-            { new Position(-560.0, 600.0), "Sunstone" },
-            { new Position(-478.0, 586.0), "SunstonePlant" },
-            { new Position(-678.1, -30.0), "MistyEntranceStompExp" },
-            { new Position(-822.3, -9.7), "MistyEntranceTreeExp" },
-            { new Position(-979.3, 23.6), "MistyFrogNookExp" },
-            { new Position(-1076.0, 32.0), "MistyKeystone1" },
-            { new Position(-1083.0, 8.3), "MistyMortarCorridorUpperExp" },
-            { new Position(-1009.0, -35.0), "MistyMortarCorridorHiddenExp" },
-            { new Position(-1102.0, -67.0), "MistyPlant" },
-            { new Position(-1188.0, -100.0), "ClimbSkillTree" },
-            { new Position(-912.0, -36.0), "MistyKeystone3" },
-            { new Position(-837.7, -123.5), "MistyPostClimbSpikeCave" },
-            { new Position(-796.0, -144.0), "MistyPostClimbAboveSpikePit" },
-            { new Position(-768.0, -144.0), "MistyKeystone4" },
-            { new Position(-671.9, -39.4), "MistyGrenade" },
-            { new Position(-1043.0, -8.0), "MistyKeystone2" },
-            { new Position(-1075.7, -2.2), "MistyAbilityCell" },
-            { new Position(-720.0, -24.0), "GumonSeal" },
-            { new Position(-168.1, -103.0), "SpiritTreeExp" }
+            new Location(new MoonGuid(new Guid("a63780b0-42b1-4774-9b29-e09860be1909")), "FirstPickup", WorldArea.Glades, LocationType.ExpSmall, new Vector2(92.0f, -227.5f)),
+            new Location(new MoonGuid(new Guid("946296aa-9449-4a2b-8d71-9d8dc9354e04")), "FirstEnergyCell", WorldArea.Glades, LocationType.EnergyCell, new Vector2(-27.4f, -256.3f)),
+            new Location(new MoonGuid(new Guid("6bb0cafc-6dd1-47f2-85dd-8567b3a60e15")), "FronkeyFight", WorldArea.Glades, LocationType.ExpSmall, new Vector2(-154.5f, -271.8f)),
+            new Location(new MoonGuid(new Guid("bc6b3f8d-e278-460e-86b6-7ece93e236ce")), "GladesKeystone1", WorldArea.Glades, LocationType.Keystone, new Vector2(83.1f, -222.3f)),
+            new Location(new MoonGuid(new Guid("e06e9d7a-e566-4594-aba9-87b8e660a89c")), "GladesKeystone2", WorldArea.Glades, LocationType.Keystone, new Vector2(-11.1f, -206.4f)),
+            new Location(new MoonGuid(new Guid("8da3969b-7ae7-4894-8801-49727a1634e7")), "GladesGrenadePool", WorldArea.Glades, LocationType.ExpLarge, new Vector2(59.0f, -280.9f)),
+            new Location(new MoonGuid(new Guid("096fb36f-de47-477e-85a2-7bb9f4a8920a")), "GladesGrenadeTree", WorldArea.Glades, LocationType.AbilityCell, new Vector2(83.0f, -196.8f)),
+            new Location(new MoonGuid(new Guid("f648eef0-1c8b-449b-bf87-8260ba65ffab")), "GladesMainPool", WorldArea.Glades, LocationType.ExpMedium, new Vector2(5.7f, -241.8f)),
+            new Location(new MoonGuid(new Guid("5c65dca8-1dab-410f-a03a-a6cdacb3a273")), "GladesMainPoolDeep", WorldArea.Glades, LocationType.EnergyCell, new Vector2(-40.1f, -239.8f)),
+            new Location(new MoonGuid(new Guid("aec98a28-a213-4a32-9149-9189ad294a82")), "FronkeyWalkRoof", WorldArea.Glades, LocationType.ExpLarge, new Vector2(257.1f, -199.7f)),
+            new Location(new MoonGuid(new Guid("5d7a6107-ca33-4820-a7cf-0a9db233d16c")), "FourthHealthCell", WorldArea.Glades, LocationType.HealthCell, new Vector2(-80.5f, -189.0f)),
+            new Location(new MoonGuid(new Guid("b4d6891b-6985-44b7-a38a-7207a2c0eb9a")), "GladesMapKeystone", WorldArea.Glades, LocationType.Keystone, new Vector2(-59.4f, -244.3f)),
+            new Location(new MoonGuid(new Guid("9be6ea7c-ea0e-4127-bf98-7d1ab19d73dd")), "WallJumpSkillTree", WorldArea.Glades, LocationType.Skill, new Vector2(-316.0f, -308.0f)),
+            new Location(new MoonGuid(new Guid("32cc3987-9ef6-461d-ae6a-f38f3288bb5d")), "LeftGladesHiddenExp", WorldArea.Glades, LocationType.ExpSmall, new Vector2(-283.4f, -236.4f)),
+            new Location(new MoonGuid(new Guid("3cb3ac42-c9ca-47be-a6dd-b5415220b07b")), "DeathGauntletExp", WorldArea.Grove, LocationType.ExpMedium, new Vector2(303.4f, -190.5f)),
+            new Location(new MoonGuid(new Guid("227e146b-13d0-4043-b0b7-f3a2ceacaa6e")), "DeathGauntletEnergyCell", WorldArea.Grotto, LocationType.EnergyCell, new Vector2(423.8f, -169.2f)),
+            new Location(new MoonGuid(new Guid("df93a803-a0b8-4c29-a46f-894babb371c9")), "GladesMap", WorldArea.Glades, LocationType.Map, new Vector2(-81.0f, -248.0f)),
+            new Location(new MoonGuid(new Guid("febeb52a-4b83-4385-b0f2-c8c3a863f646")), "AboveFourthHealth", WorldArea.Glades, LocationType.AbilityCell, new Vector2(-48.3f, -166.0f)),
+            new Location(new MoonGuid(new Guid("20aecfe4-bb54-42ef-b108-365f1bd2d2d2")), "WallJumpAreaExp", WorldArea.Glades, LocationType.ExpLarge, new Vector2(-245.7f, -277.0f)),
+            new Location(new MoonGuid(new Guid("15e6e704-70cf-4410-ae45-00ee9e9e74e1")), "WallJumpAreaEnergyCell", WorldArea.Glades, LocationType.EnergyCell, new Vector2(-336.8f, -288.2f)),
+            new Location(new MoonGuid(new Guid("3923d025-375d-4e4a-ab65-b4be0b95b47e")), "LeftGladesExp", WorldArea.Glades, LocationType.ExpSmall, new Vector2(-247.1f, -207.1f)),
+            new Location(new MoonGuid(new Guid("0e87e1d6-3fb6-47c1-a996-e54429ddf5b0")), "LeftGladesKeystone", WorldArea.Glades, LocationType.Keystone, new Vector2(-238.3f, -212.4f)),
+            new Location(new MoonGuid(new Guid("39f08f0c-9eb5-468b-a132-a1f325df358b")), "LeftGladesMapstone", WorldArea.Glades, LocationType.Mapstone, new Vector2(-184.9f, -227.6f)),
+            new Location(new MoonGuid(new Guid("9135c75e-d9c0-45ca-9b05-e4ac4bbe75fb")), "SpiritCavernsKeystone1", WorldArea.Glades, LocationType.Keystone, new Vector2(-182.1f, -194.0f)),
+            new Location(new MoonGuid(new Guid("927cd88f-8daf-462f-8e0f-5f5886fc96c4")), "SpiritCavernsKeystone2", WorldArea.Glades, LocationType.Keystone, new Vector2(-217.4f, -183.9f)),
+            new Location(new MoonGuid(new Guid("9f4f6208-7d94-42b3-a9c0-7fa64ff186f3")), "SpiritCavernsTopRightKeystone", WorldArea.Glades, LocationType.Keystone, new Vector2(-177.9f, -154.5f)),
+            new Location(new MoonGuid(new Guid("d61613b4-d469-40ab-afe7-d5ffd438ce90")), "SpiritCavernsTopLeftKeystone", WorldArea.Glades, LocationType.Keystone, new Vector2(-217.5f, -146.3f)),
+            new Location(new MoonGuid(new Guid("3d70c596-68de-4606-8f2e-c132ac4021f6")), "SpiritCavernsAbilityCell", WorldArea.Glades, LocationType.AbilityCell, new Vector2(-216.4f, -176.4f)),
+            new Location(new MoonGuid(new Guid("b905425d-a894-48ae-9c27-0b21e2b11b53")), "GladesLaser", WorldArea.Glades, LocationType.EnergyCell, new Vector2(-155.0f, -186.0f)),
+            new Location(new MoonGuid(new Guid("4319a75b-01d6-49c0-9bac-1d10f5c59a82")), "GladesLaserGrenade", WorldArea.Glades, LocationType.AbilityCell, new Vector2(-165.4f, -140.4f)),
+            new Location(new MoonGuid(new Guid("9887f949-0a02-4ca0-974d-fe400569ece9")), "SpiritTreeExp", WorldArea.Grove, LocationType.ExpMedium, new Vector2(-168.1f, -103.0f)),
+            new Location(new MoonGuid(new Guid("db35e94b-0392-48ff-990e-c24befa00a2e")), "ChargeFlameSkillTree", WorldArea.Grove, LocationType.Skill, new Vector2(-56.0f, -160.0f)),
+            new Location(new MoonGuid(new Guid("50e3ac87-6cb0-46a5-9b6d-61fc512bf491")), "ChargeFlameAreaPlant", WorldArea.Grove, LocationType.Plant, new Vector2(43.0f, -156.0f)),
+            new Location(new MoonGuid(new Guid("31ce9625-ba55-4bb3-87c0-9d4350a7e512")), "ChargeFlameAreaExp", WorldArea.Glades, LocationType.ExpMedium, new Vector2(5.0f, -193.2f)),
+            new Location(new MoonGuid(new Guid("7bbd835d-c1cb-4144-be49-5df3d7e76835")), "AboveChargeFlameTreeExp", WorldArea.Grove, LocationType.ExpMedium, new Vector2(-14.2f, -95.7f)),
+            new Location(new MoonGuid(new Guid("9a078c11-d254-4bef-823f-9b8c9a224936")), "SpiderSacEnergyDoor", WorldArea.Grove, LocationType.AbilityCell, new Vector2(64.0f, -109.4f)),
+            new Location(new MoonGuid(new Guid("41d64105-b524-4a62-85fd-a44e0c458ff8")), "SpiderSacHealthCell", WorldArea.Grove, LocationType.HealthCell, new Vector2(151.8f, -117.8f)),
+            new Location(new MoonGuid(new Guid("e03c5ccc-09ed-4f74-9aa2-82335dd6f538")), "SpiderSacEnergyCell", WorldArea.Grove, LocationType.EnergyCell, new Vector2(60.7f, -155.8f)),
+            new Location(new MoonGuid(new Guid("82e91575-ec36-4bfa-b050-e87fc3684cb5")), "SpiderSacGrenadeDoor", WorldArea.Grove, LocationType.AbilityCell, new Vector2(93.4f, -92.5f)),
+            new Location(new MoonGuid(new Guid("fac86702-fb8e-4f69-9c10-875ca4c054d3")), "DashAreaOrbRoomExp", WorldArea.Blackroot, LocationType.ExpMedium, new Vector2(154.0f, -291.5f)),
+            new Location(new MoonGuid(new Guid("a0e20125-fd8d-403e-8f05-18bc816178fb")), "DashAreaAbilityCell", WorldArea.Blackroot, LocationType.AbilityCell, new Vector2(183.8f, -291.5f)),
+            new Location(new MoonGuid(new Guid("a8959482-6024-4de2-9c4a-85904321498a")), "DashAreaRoofExp", WorldArea.Blackroot, LocationType.ExpMedium, new Vector2(197.3f, -229.1f)),
+            new Location(new MoonGuid(new Guid("bb0847e0-a88b-4449-9bf6-f9944e5024df")), "DashSkillTree", WorldArea.Blackroot, LocationType.Skill, new Vector2(292.0f, -256.0f)),
+            new Location(new MoonGuid(new Guid("a334b21b-691d-4b79-b149-4027b2aed3e5")), "DashAreaPlant", WorldArea.Blackroot, LocationType.Plant, new Vector2(313.0f, -232.0f)),
+            new Location(new MoonGuid(new Guid("821112d5-830d-4dd0-a16c-6f574a4122aa")), "RazielNo", WorldArea.Blackroot, LocationType.ExpMedium, new Vector2(304.4f, -303.2f)),
+            new Location(new MoonGuid(new Guid("c09a7bd5-d703-40ec-92b9-c3a840478aa8")), "DashAreaMapstone", WorldArea.Blackroot, LocationType.Mapstone, new Vector2(346.0f, -255.0f)),
+            new Location(new MoonGuid(new Guid("b73d5139-430f-4076-8357-91638db8aa4c")), "BlackrootTeleporterHealthCell", WorldArea.Blackroot, LocationType.HealthCell, new Vector2(395.0f, -309.1f)),
+            new Location(new MoonGuid(new Guid("6b12d651-6eae-46b3-9949-94fa73404a45")), "BlackrootMap", WorldArea.Blackroot, LocationType.Map, new Vector2(418.0f, -291.0f)),
+            new Location(new MoonGuid(new Guid("965ca68c-a41d-47a4-ac63-64a932c04177")), "BlackrootBoulderExp", WorldArea.Blackroot, LocationType.ExpMedium, new Vector2(432.0f, -324.0f)),
+            new Location(new MoonGuid(new Guid("a90db45e-56b4-405b-80d6-83bc4607b921")), "GrenadeSkillTree", WorldArea.Blackroot, LocationType.Skill, new Vector2(72.0f, -380.0f)),
+            new Location(new MoonGuid(new Guid("f9f705a1-e2c4-4856-a6b3-ce08a0b15807")), "GrenadeAreaExp", WorldArea.Blackroot, LocationType.ExpMedium, new Vector2(224.0f, -359.1f)),
+            new Location(new MoonGuid(new Guid("bcd84bf8-2b02-442a-bd2d-798687ead2aa")), "GrenadeAreaAbilityCell", WorldArea.Blackroot, LocationType.AbilityCell, new Vector2(252.4f, -331.9f)),
+            new Location(new MoonGuid(new Guid("07983731-614c-4123-8bec-1eb036fbdceb")), "LowerBlackrootAbilityCell", WorldArea.Blackroot, LocationType.AbilityCell, new Vector2(279.0f, -375.0f)),
+            new Location(new MoonGuid(new Guid("66dabcc6-dafa-47a4-9c2d-0be6f915198c")), "LowerBlackrootLaserAbilityCell", WorldArea.Blackroot, LocationType.AbilityCell, new Vector2(391.5f, -423.0f)),
+            new Location(new MoonGuid(new Guid("e9cec978-351e-4ab4-b37b-c3d90b11e17e")), "LowerBlackrootLaserExp", WorldArea.Blackroot, LocationType.ExpMedium, new Vector2(339.0f, -418.8f)),
+            new Location(new MoonGuid(new Guid("d8e6c0cd-f194-4913-8776-f23882161070")), "LowerBlackrootGrenadeThrow", WorldArea.Blackroot, LocationType.AbilityCell, new Vector2(208.5f, -431.5f)),
+            new Location(new MoonGuid(new Guid("b4f9a336-4147-49e4-8ea6-83d46493c154")), "LostGroveAbilityCell", WorldArea.Blackroot, LocationType.AbilityCell, new Vector2(459.5f, -506.8f)),
+            new Location(new MoonGuid(new Guid("c06b2949-b01a-4c67-a44f-ae2c9476ebb8")), "LostGroveHiddenExp", WorldArea.Blackroot, LocationType.ExpMedium, new Vector2(462.4f, -489.5f)),
+            new Location(new MoonGuid(new Guid("aa4ee768-a4ab-456f-8c38-4d7433ca6c81")), "LostGroveTeleporter", WorldArea.Blackroot, LocationType.ExpMedium, new Vector2(307.3f, -525.2f)),
+            new Location(new MoonGuid(new Guid("1a3b17d1-5331-4315-885c-c4a012e527f4")), "LostGroveLongSwim", WorldArea.Blackroot, LocationType.AbilityCell, new Vector2(527.0f, -544.0f)),
+            new Location(new MoonGuid(new Guid("f1d27bac-0911-4a0e-8901-626982bb909e")), "HollowGroveMapstone", WorldArea.Grove, LocationType.Mapstone, new Vector2(300.0f, -94.0f)),
+            new Location(new MoonGuid(new Guid("6e75862e-6c9f-488a-b4cf-760dcaa22f9e")), "OuterSwampAbilityCell", WorldArea.Swamp, LocationType.AbilityCell, new Vector2(703.2f, -82.3f)),
+            new Location(new MoonGuid(new Guid("5e0ff4fa-86c1-4ac6-afd3-94734b0ec95b")), "OuterSwampStompExp", WorldArea.Swamp, LocationType.ExpMedium, new Vector2(618.5f, -98.0f)),
+            new Location(new MoonGuid(new Guid("c7978ab3-94f4-4040-b4a6-0d254d03017a")), "OuterSwampHealthCell", WorldArea.Swamp, LocationType.HealthCell, new Vector2(581.5f, -67.0f)),
+            new Location(new MoonGuid(new Guid("fd4e2fed-e523-4327-9db6-667088becf80")), "HollowGroveMap", WorldArea.Grove, LocationType.Map, new Vector2(351.0f, -119.0f)),
+            new Location(new MoonGuid(new Guid("ffb8ac3d-8be4-4dbf-aa37-c7cec997d207")), "HollowGroveTreeAbilityCell", WorldArea.Grove, LocationType.AbilityCell, new Vector2(333.1f, -61.9f)),
+            new Location(new MoonGuid(new Guid("8f928efd-0550-4c86-835a-d813bd8aacd3")), "HollowGroveMapPlant", WorldArea.Grove, LocationType.Plant, new Vector2(365.0f, -119.0f)),
+            new Location(new MoonGuid(new Guid("5a507a02-ede0-4720-8db8-d1a0e3e99929")), "HollowGroveTreePlant", WorldArea.Grove, LocationType.Plant, new Vector2(330.0f, -78.0f)),
+            new Location(new MoonGuid(new Guid("216d4b2e-843f-462d-a04a-155da8b2938f")), "SwampEntrancePlant", WorldArea.Swamp, LocationType.Plant, new Vector2(628.0f, -120.0f)),
+            new Location(new MoonGuid(new Guid("f647b2e0-1032-4cea-9fa9-f13e0ffa660f")), "MoonGrottoStompPlant", WorldArea.Grotto, LocationType.Plant, new Vector2(435.0f, -140.0f)),
+            new Location(new MoonGuid(new Guid("07e6b6ae-01ba-42cf-b468-b32d2347feb3")), "OuterSwampMortarPlant", WorldArea.Swamp, LocationType.Plant, new Vector2(515.0f, -100.0f)),
+            new Location(new MoonGuid(new Guid("5db1c38e-62da-4839-b5dd-1b28db826a1c")), "GroveWaterStompAbilityCell", WorldArea.Grove, LocationType.AbilityCell, new Vector2(354.0f, -178.5f)),
+            new Location(new MoonGuid(new Guid("308487d6-451c-40f4-86a2-631ea7a4ff93")), "OuterSwampGrenadeExp", WorldArea.Swamp, LocationType.ExpLarge, new Vector2(666.0f, -48.0f)),
+            new Location(new MoonGuid(new Guid("3dc121cd-1460-4387-aad8-88c700d97dab")), "SwampTeleporterAbilityCell", WorldArea.Swamp, LocationType.AbilityCell, new Vector2(409.5f, -34.5f)),
+            new Location(new MoonGuid(new Guid("a36910b8-8ab6-4097-8f18-3548d4bc2ebc")), "GroveAboveSpiderWaterExp", WorldArea.Grove, LocationType.ExpLarge, new Vector2(174.2f, -105.6f)),
+            new Location(new MoonGuid(new Guid("4570a95a-58c8-41bd-b5b3-13948d1cecf1")), "GroveAboveSpiderWaterHealthCell", WorldArea.Grove, LocationType.HealthCell, new Vector2(261.4f, -117.7f)),
+            new Location(new MoonGuid(new Guid("01216f37-d036-4d76-ab97-5036b92121b0")), "GroveAboveSpiderWaterEnergyCell", WorldArea.Grove, LocationType.EnergyCell, new Vector2(272.5f, -97.5f)),
+            new Location(new MoonGuid(new Guid("111c6aa1-9b11-49d6-b20e-80af97f0c8c7")), "GroveSpiderWaterSwim", WorldArea.Grove, LocationType.ExpMedium, new Vector2(187.3f, -163.9f)),
+            new Location(new MoonGuid(new Guid("cf38993c-f94f-45b8-b0f9-119e257c02d7")), "DeathGauntletSwimEnergyDoor", WorldArea.Grove, LocationType.AbilityCell, new Vector2(339.0f, -216.0f)),
+            new Location(new MoonGuid(new Guid("c563573f-ebfc-4b8f-8e2d-16aebd0a8698")), "DeathGauntletStompSwim", WorldArea.Grotto, LocationType.ExpLarge, new Vector2(356.8f, -207.1f)),
+            new Location(new MoonGuid(new Guid("9eeb188b-99e3-4783-bbe6-e5440fe8faca")), "AboveGrottoTeleporterExp", WorldArea.Grotto, LocationType.ExpMedium, new Vector2(477.0f, -140.0f)),
+            new Location(new MoonGuid(new Guid("93918644-d27f-48fa-a1ae-4587dfc1af39")), "GrottoLasersRoofExp", WorldArea.Grotto, LocationType.ExpMedium, new Vector2(432.0f, -108.0f)),
+            new Location(new MoonGuid(new Guid("45d1f68e-1e7b-4bad-8f20-185f34fe8c8a")), "IcelessExp", WorldArea.Grove, LocationType.ExpMedium, new Vector2(365.2f, -109.1f)),
+            new Location(new MoonGuid(new Guid("7774dc60-7d2c-43cf-8be8-75a2eb8ad89e")), "BelowGrottoTeleporterPlant", WorldArea.Grotto, LocationType.Plant, new Vector2(540.0f, -220.0f)),
+            new Location(new MoonGuid(new Guid("fe6f5315-4db5-42e9-b240-d25ae5e4aff2")), "LeftGrottoTeleporterExp", WorldArea.Grotto, LocationType.ExpLarge, new Vector2(450.0f, -166.8f)),
+            new Location(new MoonGuid(new Guid("cb8e6952-0852-4337-84ac-4adbca2e2b73")), "OuterSwampMortarAbilityCell", WorldArea.Swamp, LocationType.AbilityCell, new Vector2(502.0f, -108.0f)),
+            new Location(new MoonGuid(new Guid("56a4b631-7d43-4fda-9d5f-ac1d454bcab9")), "SwampEntranceSwim", WorldArea.Swamp, LocationType.ExpLarge, new Vector2(595.0f, -136.0f)),
+            new Location(new MoonGuid(new Guid("818751c2-f958-4afa-b71d-d39f9853461d")), "BelowGrottoTeleporterHealthCell", WorldArea.Grotto, LocationType.HealthCell, new Vector2(543.6f, -189.4f)),
+            new Location(new MoonGuid(new Guid("dbc518b6-ec15-4d73-88c0-0aee01e1614c")), "GrottoEnergyDoorSwim", WorldArea.Grotto, LocationType.ExpMedium, new Vector2(423.0f, -274.0f)),
+            new Location(new MoonGuid(new Guid("80ba61d0-281f-4fe8-883a-0b04320a5200")), "GrottoEnergyDoorHealthCell", WorldArea.Grotto, LocationType.HealthCell, new Vector2(424.0f, -220.0f)),
+            new Location(new MoonGuid(new Guid("a3e8287b-7f53-497f-9dd2-92e6807d9f35")), "GrottoSwampDrainAccessExp", WorldArea.Grotto, LocationType.ExpMedium, new Vector2(552.0f, -141.5f)),
+            new Location(new MoonGuid(new Guid("97361c03-6a9c-4e7e-afc2-bbd1fff37ef8")), "GrottoSwampDrainAccessPlant", WorldArea.Grotto, LocationType.Plant, new Vector2(537.0f, -176.0f)),
+            new Location(new MoonGuid(new Guid("ac4c2a10-b3c3-4805-bc4d-d8dd51b2fe34")), "GrottoHideoutFallAbilityCell", WorldArea.Grotto, LocationType.AbilityCell, new Vector2(451.0f, -296.0f)),
+            new Location(new MoonGuid(new Guid("eb9be108-9834-4192-a14b-cc6ca5c5eb7a")), "GumoHideoutMapstone", WorldArea.Grotto, LocationType.Mapstone, new Vector2(513.0f, -413.0f)),
+            new Location(new MoonGuid(new Guid("e2a87ba7-6179-439e-b610-0f424d600fef")), "GumoHideoutMiniboss", WorldArea.Grotto, LocationType.Keystone, new Vector2(620.0f, -404.0f)),
+            new Location(new MoonGuid(new Guid("ce03775a-859f-4117-b88c-4e5cdcd63abe")), "GumoHideoutCrusherExp", WorldArea.Grotto, LocationType.ExpMedium, new Vector2(572.5f, -378.5f)),
+            new Location(new MoonGuid(new Guid("4cd7b2de-aa6d-4ea6-99f0-ed4748765194")), "GumoHideoutCrusherKeystone", WorldArea.Grotto, LocationType.Keystone, new Vector2(590.0f, -384.0f)),
+            new Location(new MoonGuid(new Guid("e9324310-3a82-49ec-8823-1b79e828b65f")), "GumoHideoutRightHangingExp", WorldArea.Grotto, LocationType.ExpSmall, new Vector2(496.0f, -369.0f)),
+            new Location(new MoonGuid(new Guid("c54266b0-44eb-4ef9-86cd-8efa8f0e3377")), "GumoHideoutLeftHangingExp", WorldArea.Grotto, LocationType.ExpSmall, new Vector2(467.5f, -369.0f)),
+            new Location(new MoonGuid(new Guid("f8c47a8b-74d8-495f-8920-a2fcb9c83a0a")), "GumoHideoutRedirectAbilityCell", WorldArea.Grotto, LocationType.AbilityCell, new Vector2(449.0f, -430.0f)),
+            new Location(new MoonGuid(new Guid("5051e7e8-3361-46fc-9edf-8470b28bf7df")), "GumoHideoutMap", WorldArea.Grotto, LocationType.Map, new Vector2(477.0f, -389.0f)),
+            new Location(new MoonGuid(new Guid("83a91676-9217-4d5f-8ae5-ef6189d6ebfe")), "DoubleJumpSkillTree", WorldArea.Grotto, LocationType.Skill, new Vector2(784.0f, -412.0f)),
+            new Location(new MoonGuid(new Guid("5601a577-4fe0-4baa-aa82-24baa01ebcd8")), "DoubleJumpAreaExp", WorldArea.Grotto, LocationType.ExpMedium, new Vector2(759.0f, -398.0f)),
+            new Location(new MoonGuid(new Guid("1a34da08-b071-434c-bb16-5061d90dbb23")), "GumoHideoutEnergyCell", WorldArea.Grotto, LocationType.EnergyCell, new Vector2(545.8f, -357.9f)),
+            new Location(new MoonGuid(new Guid("76b64647-1a59-4fa5-8dbc-9a9db47afe6e")), "GumoHideoutRockfallExp", WorldArea.Grotto, LocationType.ExpMedium, new Vector2(567.6f, -246.2f)),
+            new Location(new MoonGuid(new Guid("ed6776f6-fe53-4fdc-b6c3-82ae8863a0a7")), "WaterVein", WorldArea.Grotto, LocationType.Event, new Vector2(500.0f, -248.0f)),
+            new Location(new MoonGuid(new Guid("99d20fdb-93ae-4a56-8099-50db65fcc038")), "LeftGumoHideoutExp", WorldArea.Grotto, LocationType.ExpMedium, new Vector2(406.9f, -386.2f)),
+            new Location(new MoonGuid(new Guid("055b2efc-5c0d-48df-b459-c0597a6157a0")), "LeftGumoHideoutHealthCell", WorldArea.Grotto, LocationType.HealthCell, new Vector2(393.8f, -375.6f)),
+            new Location(new MoonGuid(new Guid("f26afebd-eb6e-4632-b221-92d933a9ce71")), "LeftGumoHideoutLowerPlant", WorldArea.Grotto, LocationType.Plant, new Vector2(447.0f, -368.0f)),
+            new Location(new MoonGuid(new Guid("1e5ffc6a-4955-442e-8e55-83cc6dc98bae")), "LeftGumoHideoutUpperPlant", WorldArea.Grotto, LocationType.Plant, new Vector2(439.0f, -344.0f)),
+            new Location(new MoonGuid(new Guid("aae4f932-9adf-493b-a7c2-610f7155800b")), "GumoHideoutRedirectPlant", WorldArea.Grotto, LocationType.Plant, new Vector2(492.0f, -400.0f)),
+            new Location(new MoonGuid(new Guid("3848b58f-6b4d-458c-82c5-d12da775c239")), "LeftGumoHideoutSwim", WorldArea.Grotto, LocationType.ExpMedium, new Vector2(397.0f, -411.5f)),
+            new Location(new MoonGuid(new Guid("191a7af3-09ce-400a-b46f-c42e3795a91a")), "GumoHideoutRedirectEnergyCell", WorldArea.Grotto, LocationType.EnergyCell, new Vector2(515.4f, -441.9f)),
+            new Location(new MoonGuid(new Guid("effd752c-50ad-4ac0-95fd-fae40eee581c")), "GumoHideoutRedirectExp", WorldArea.Grotto, LocationType.ExpLarge, new Vector2(505.3f, -439.4f)),
+            new Location(new MoonGuid(new Guid("5525f151-36cf-44bf-924b-8a0ccc9f7854")), "FarLeftGumoHideoutExp", WorldArea.Grotto, LocationType.ExpMedium, new Vector2(328.9f, -353.7f)),
+            new Location(new MoonGuid(new Guid("d903d308-ba71-4ed4-a5a8-27d1c01250e3")), "SwampEntranceAbilityCell", WorldArea.Swamp, LocationType.AbilityCell, new Vector2(643.5f, -127.5f)),
+            new Location(new MoonGuid(new Guid("981f27e8-b14d-474a-a2f0-99eb418d45a1")), "DeathGauntletRoofHealthCell", WorldArea.Grove, LocationType.HealthCell, new Vector2(321.7f, -179.1f)),
+            new Location(new MoonGuid(new Guid("9b46304b-0b29-4d72-bb28-c6068ef3304b")), "DeathGauntletRoofPlant", WorldArea.Grove, LocationType.Plant, new Vector2(342.0f, -179.0f)),
+            new Location(new MoonGuid(new Guid("0f0951ec-975e-446d-b434-259a40dde5cc")), "LowerGinsoHiddenExp", WorldArea.Ginso, LocationType.ExpMedium, new Vector2(523.0f, 142.0f)),
+            new Location(new MoonGuid(new Guid("930cc8c6-d894-4be9-8b68-5ddb33e2cc9a")), "LowerGinsoKeystone1", WorldArea.Ginso, LocationType.Keystone, new Vector2(531.0f, 267.0f)),
+            new Location(new MoonGuid(new Guid("10d7d1cd-05a1-4cda-8358-ffb70309ada4")), "LowerGinsoKeystone2", WorldArea.Ginso, LocationType.Keystone, new Vector2(540.0f, 277.0f)),
+            new Location(new MoonGuid(new Guid("35b2689e-8ecb-4f4d-9434-10b9bfdc778e")), "LowerGinsoKeystone3", WorldArea.Ginso, LocationType.Keystone, new Vector2(508.0f, 304.0f)),
+            new Location(new MoonGuid(new Guid("dd7b36d5-af5a-44dc-8f2f-071d2729c35a")), "LowerGinsoKeystone4", WorldArea.Ginso, LocationType.Keystone, new Vector2(529.0f, 297.0f)),
+            new Location(new MoonGuid(new Guid("d15bed0b-b493-4931-8822-4f8c91a782d3")), "LowerGinsoPlant", WorldArea.Ginso, LocationType.Plant, new Vector2(540.0f, 101.0f)),
+            new Location(new MoonGuid(new Guid("d094cce4-3b65-454f-b5c9-7e6ed7dcc436")), "BashSkillTree", WorldArea.Ginso, LocationType.Skill, new Vector2(532.0f, 328.0f)),
+            new Location(new MoonGuid(new Guid("32419a38-e045-48dc-b9af-84f192f34b68")), "BashAreaExp", WorldArea.Ginso, LocationType.ExpMedium, new Vector2(518.4f, 339.8f)),
+            new Location(new MoonGuid(new Guid("e5d4683c-2909-4d5a-b5a2-6184af83f66f")), "UpperGinsoLowerKeystone", WorldArea.Ginso, LocationType.Keystone, new Vector2(507.0f, 476.0f)),
+            new Location(new MoonGuid(new Guid("94a7bf35-e1f1-4be6-ab6d-276d18e36fe6")), "UpperGinsoRightKeystone", WorldArea.Ginso, LocationType.Keystone, new Vector2(535.0f, 488.0f)),
+            new Location(new MoonGuid(new Guid("dff38fe5-bc28-4709-875e-4cc7870484b1")), "UpperGinsoUpperRightKeystone", WorldArea.Ginso, LocationType.Keystone, new Vector2(531.0f, 502.0f)),
+            new Location(new MoonGuid(new Guid("b3e67ad6-4be0-4fba-b3a9-84dca30eb78e")), "UpperGinsoUpperLeftKeystone", WorldArea.Ginso, LocationType.Keystone, new Vector2(508.0f, 498.0f)),
+            new Location(new MoonGuid(new Guid("290b4d70-e069-4bab-948a-473bdb723377")), "UpperGinsoRedirectLowerExp", WorldArea.Ginso, LocationType.ExpMedium, new Vector2(517.1f, 384.4f)),
+            new Location(new MoonGuid(new Guid("dad100fb-2cd5-4796-9eb3-5833e513a583")), "UpperGinsoRedirectUpperExp", WorldArea.Ginso, LocationType.ExpMedium, new Vector2(530.5f, 407.0f)),
+            new Location(new MoonGuid(new Guid("86516ca1-f515-4d4c-a01a-48370ad334d6")), "UpperGinsoEnergyCell", WorldArea.Ginso, LocationType.EnergyCell, new Vector2(536.6f, 434.7f)),
+            new Location(new MoonGuid(new Guid("a72abfba-4389-4714-a5f4-1fd606ac7dd8")), "TopGinsoLeftLowerExp", WorldArea.Ginso, LocationType.ExpMedium, new Vector2(456.9f, 566.1f)),
+            new Location(new MoonGuid(new Guid("abaaf3cb-a9f3-45f0-8755-c09dc03dfdfa")), "TopGinsoLeftUpperExp", WorldArea.Ginso, LocationType.ExpMedium, new Vector2(471.2f, 614.8f)),
+            new Location(new MoonGuid(new Guid("008f4c83-8e59-4640-9bdd-ac60a7c121c0")), "TopGinsoRightPlant", WorldArea.Ginso, LocationType.Plant, new Vector2(610.0f, 611.0f)),
+            new Location(new MoonGuid(new Guid("41f363b4-1d7b-4788-9bf0-66d56fd82b9c")), "GinsoEscapeSpiderExp", WorldArea.Ginso, LocationType.ExpLarge, new Vector2(534.5f, 661.5f)),
+            new Location(new MoonGuid(new Guid("38f99d93-1c86-4ca5-a782-4c79a8f30311")), "GinsoEscapeJumpPadExp", WorldArea.Ginso, LocationType.ExpMedium, new Vector2(537.5f, 733.6f)),
+            new Location(new MoonGuid(new Guid("3b098597-20a4-4471-80bd-d0bf1d84ed14")), "GinsoEscapeProjectileExp", WorldArea.Ginso, LocationType.ExpMedium, new Vector2(533.5f, 827.3f)),
+            new Location(new MoonGuid(new Guid("fb37b950-223e-4e1e-9261-11fa135a4bde")), "GinsoEscapeHangingExp", WorldArea.Ginso, LocationType.ExpMedium, new Vector2(519.3f, 867.6f)),
+            new Location(new MoonGuid(new Guid("12728fe9-7224-46aa-b315-7790e2bd8efc")), "GinsoEscapeExit", WorldArea.Ginso, LocationType.Event, new Vector2(548.0f, 952.0f)),
+            new Location(new MoonGuid(new Guid("d5e3a6dc-2cd8-46da-9120-6863dfce00bd")), "SwampMap", WorldArea.Swamp, LocationType.Map, new Vector2(677.0f, -129.0f)),
+            new Location(new MoonGuid(new Guid("d1306ce2-990b-4d51-bce3-2e5557927670")), "InnerSwampDrainExp", WorldArea.Swamp, LocationType.ExpMedium, new Vector2(637.0f, -162.2f)),
+            new Location(new MoonGuid(new Guid("d1f5b054-1050-44dd-bd77-53cc3d430dd3")), "InnerSwampHiddenSwimExp", WorldArea.Swamp, LocationType.ExpMedium, new Vector2(761.9f, -173.5f)),
+            new Location(new MoonGuid(new Guid("f7c585e3-3b73-42ab-8664-56a17a85a238")), "InnerSwampSwimLeftKeystone", WorldArea.Swamp, LocationType.Keystone, new Vector2(684.0f, -205.0f)),
+            new Location(new MoonGuid(new Guid("0cc53366-fc0f-4163-9021-ece2ae0751bc")), "InnerSwampSwimRightKeystone", WorldArea.Swamp, LocationType.Keystone, new Vector2(766.0f, -183.0f)),
+            new Location(new MoonGuid(new Guid("a976fb6d-0db9-4ff3-becb-fd8cb98e7e98")), "InnerSwampSwimMapstone", WorldArea.Swamp, LocationType.Mapstone, new Vector2(796.0f, -210.0f)),
+            new Location(new MoonGuid(new Guid("ebe89d18-678d-4654-84a2-ca94fe1831a2")), "InnerSwampStompExp", WorldArea.Swamp, LocationType.ExpMedium, new Vector2(770.9f, -148.0f)),
+            new Location(new MoonGuid(new Guid("2da844e9-4e55-4ec0-a71a-b0c6abd6e1b0")), "InnerSwampEnergyCell", WorldArea.Swamp, LocationType.EnergyCell, new Vector2(722.3f, -95.5f)),
+            new Location(new MoonGuid(new Guid("d02c2919-1426-44e9-a72b-f48a6c7c68e1")), "StompSkillTree", WorldArea.Swamp, LocationType.Skill, new Vector2(860.0f, -96.0f)),
+            new Location(new MoonGuid(new Guid("08edaf56-f649-4e8c-8ee6-0fab727507d7")), "StompAreaRoofExp", WorldArea.Swamp, LocationType.ExpLarge, new Vector2(914.9f, -71.3f)),
+            new Location(new MoonGuid(new Guid("9f0907c3-fc53-4943-910e-79cef197c9bf")), "StompAreaExp", WorldArea.Swamp, LocationType.ExpMedium, new Vector2(884.0f, -98.3f)),
+            new Location(new MoonGuid(new Guid("195e0dd8-4871-40db-9c6a-a8912684e944")), "StompAreaGrenadeExp", WorldArea.Swamp, LocationType.ExpLarge, new Vector2(874.2f, -143.6f)),
+            new Location(new MoonGuid(new Guid("dbd78938-437d-4bad-bac3-6f9f3471fd62")), "HoruFieldsHiddenExp", WorldArea.Grove, LocationType.ExpLarge, new Vector2(97.5f, -37.9f)),
+            new Location(new MoonGuid(new Guid("82db7562-639e-4a64-ab5e-f042096c5d9b")), "HoruFieldsEnergyCell", WorldArea.Grove, LocationType.EnergyCell, new Vector2(175.9f, 1.0f)),
+            new Location(new MoonGuid(new Guid("1b390cdd-e654-4a83-8aa6-d5235333a1c4")), "HoruFieldsPlant", WorldArea.Grove, LocationType.Plant, new Vector2(124.0f, 21.0f)),
+            new Location(new MoonGuid(new Guid("83819798-2573-4af5-8bf9-70c5d9d0c68d")), "HoruFieldsAbilityCell", WorldArea.Grove, LocationType.AbilityCell, new Vector2(176.8f, -34.6f)),
+            new Location(new MoonGuid(new Guid("79cf7fce-01e9-44a3-8568-f2b243baeb7d")), "HoruFieldsHealthCell", WorldArea.Grove, LocationType.HealthCell, new Vector2(160.3f, -78.4f)),
+            new Location(new MoonGuid(new Guid("91da766a-938d-49d4-bae1-41c015618da6")), "HoruMap", WorldArea.Horu, LocationType.Map, new Vector2(56.0f, 343.0f)),
+            new Location(new MoonGuid(new Guid("88d96765-325c-4dfc-9167-25020be791d9")), "HoruL4LowerExp", WorldArea.Horu, LocationType.ExpLarge, new Vector2(-29.8f, 148.9f)),
+            new Location(new MoonGuid(new Guid("22e628e7-af91-4630-8e1c-b9d6ce0a7fcd")), "HoruL4ChaseExp", WorldArea.Horu, LocationType.ExpLarge, new Vector2(-191.7f, 194.4f)),
+            new Location(new MoonGuid(new Guid("7523b755-e9e4-407e-83ef-1c1f7210d310")), "HoruLavaDrainedLeftExp", WorldArea.Horu, LocationType.ExpLarge, new Vector2(13.5f, 164.3f)),
+            new Location(new MoonGuid(new Guid("a2512573-18dc-46c4-81da-5e5a2ec38f10")), "HoruR1HangingExp", WorldArea.Horu, LocationType.ExpMedium, new Vector2(193.8f, 384.9f)),
+            new Location(new MoonGuid(new Guid("d368611b-b65c-432d-b62b-2c15b33eccfd")), "HoruR1Mapstone", WorldArea.Horu, LocationType.Mapstone, new Vector2(148.0f, 363.0f)),
+            new Location(new MoonGuid(new Guid("61414408-5868-442c-9abf-728f9fb0f4a7")), "HoruR1EnergyCell", WorldArea.Horu, LocationType.EnergyCell, new Vector2(249.4f, 403.0f)),
+            new Location(new MoonGuid(new Guid("9c56d300-6891-4876-9756-2659b8887ad3")), "HoruR3Plant", WorldArea.Horu, LocationType.Plant, new Vector2(318.0f, 245.0f)),
+            new Location(new MoonGuid(new Guid("5b154bb4-59ea-4135-96a8-d7cfb51870eb")), "HoruR4StompExp", WorldArea.Horu, LocationType.ExpLarge, new Vector2(191.7f, 165.2f)),
+            new Location(new MoonGuid(new Guid("b9240859-43a5-428b-a81d-ba79a65cf253")), "HoruR4LaserExp", WorldArea.Horu, LocationType.ExpLarge, new Vector2(253.5f, 194.6f)),
+            new Location(new MoonGuid(new Guid("01ea51a6-9586-4d16-ac13-847fec4637e0")), "HoruR4DrainedExp", WorldArea.Horu, LocationType.ExpLarge, new Vector2(163.4f, 136.4f)),
+            new Location(new MoonGuid(new Guid("753b9eef-37af-45ae-8628-194312e1c752")), "HoruLavaDrainedRightExp", WorldArea.Horu, LocationType.ExpLarge, new Vector2(129.8f, 165.6f)),
+            new Location(new MoonGuid(new Guid("1e459051-fb73-4ce9-82e3-43777566bf19")), "HoruL1", WorldArea.Horu, LocationType.Cutscene, new Vector2(-92.0f, 376.0f)),
+            new Location(new MoonGuid(new Guid("1a7fd156-3c71-4618-99ee-454c9aab2f27")), "HoruL2", WorldArea.Horu, LocationType.Cutscene, new Vector2(-20.0f, 276.0f)),
+            new Location(new MoonGuid(new Guid("14684bd4-ce7e-4c3d-ba2d-4673104d8e86")), "HoruL3", WorldArea.Horu, LocationType.Cutscene, new Vector2(-164.0f, 336.0f)),
+            new Location(new MoonGuid(new Guid("f93ca13c-c7bc-4b3f-bcc0-3c7b30b2c4a9")), "HoruL4", WorldArea.Horu, LocationType.Cutscene, new Vector2(-96.0f, 152.0f)),
+            new Location(new MoonGuid(new Guid("726bbbb9-339f-4b6f-baf0-05a02c215385")), "HoruR1", WorldArea.Horu, LocationType.Cutscene, new Vector2(264.0f, 380.0f)),
+            new Location(new MoonGuid(new Guid("46555a18-aec8-4943-a12b-fa5782d65b42")), "HoruR2", WorldArea.Horu, LocationType.Cutscene, new Vector2(172.0f, 288.0f)),
+            new Location(new MoonGuid(new Guid("7cdc17a4-5448-44c2-890a-ce1ba09f6e66")), "HoruR3", WorldArea.Horu, LocationType.Cutscene, new Vector2(304.0f, 304.0f)),
+            new Location(new MoonGuid(new Guid("4dc498b4-9f8d-4779-ab12-4cce964d211d")), "HoruR4", WorldArea.Horu, LocationType.Cutscene, new Vector2(216.0f, 192.0f)),
+            new Location(new MoonGuid(new Guid("09b053bd-87bb-4718-9419-e5689f618233")), "DoorWarpExp", WorldArea.Horu, LocationType.ExpLarge, new Vector2(106.5f, 112.0f)),
+            new Location(new MoonGuid(new Guid("ca00fedb-6d8d-4091-95aa-4e49d9583a1c")), "HoruTeleporterExp", WorldArea.Horu, LocationType.ExpLarge, new Vector2(98.0f, 130.5f)),
+            new Location(new MoonGuid(new Guid("956197d9-4af7-452c-931a-2c45f33435d2")), "ValleyEntryAbilityCell", WorldArea.Valley, LocationType.AbilityCell, new Vector2(-206.0f, -113.3f)),
+            new Location(new MoonGuid(new Guid("f39ac231-0153-4a0a-b897-ebcb6dafb626")), "ValleyEntryTreeExp", WorldArea.Valley, LocationType.ExpMedium, new Vector2(-221.0f, -84.0f)),
+            new Location(new MoonGuid(new Guid("3dac0d06-0ea7-466c-a959-9583f15f1d56")), "ValleyEntryTreePlant", WorldArea.Valley, LocationType.Plant, new Vector2(-179.0f, -88.0f)),
+            new Location(new MoonGuid(new Guid("cd85689a-a50c-4923-8621-135a443a76f9")), "ValleyEntryGrenadeLongSwim", WorldArea.Valley, LocationType.EnergyCell, new Vector2(-320.0f, -162.0f)),
+            new Location(new MoonGuid(new Guid("dcb47a2b-3a57-45ef-80c7-a58a2861972b")), "ValleyRightFastStomplessCell", WorldArea.Valley, LocationType.AbilityCell, new Vector2(-355.4f, 65.6f)),
+            new Location(new MoonGuid(new Guid("4ca2a5dd-bfeb-4c25-95a2-61e6b0c37d07")), "ValleyRightExp", WorldArea.Valley, LocationType.ExpMedium, new Vector2(-418.8f, 67.5f)),
+            new Location(new MoonGuid(new Guid("3c8775ce-69a3-402e-869f-e78529dab898")), "ValleyRightBirdStompCell", WorldArea.Valley, LocationType.AbilityCell, new Vector2(-292.0f, 20.7f)),
+            new Location(new MoonGuid(new Guid("77ab5ca3-78e5-4c95-80bf-c829fe0db9cb")), "GlideSkillFeather", WorldArea.Valley, LocationType.Skill, new Vector2(-460.0f, -20.0f)),
+            new Location(new MoonGuid(new Guid("a7ec42f9-1245-447f-b14c-2af1a282c12b")), "KuroPerchExp", WorldArea.Sorrow, LocationType.ExpLarge, new Vector2(-546.2f, 54.4f)),
+            new Location(new MoonGuid(new Guid("c7529078-8db5-40a8-8564-c7d568dc9fef")), "ValleyMap", WorldArea.Valley, LocationType.Map, new Vector2(-408.0f, -170.0f)),
+            new Location(new MoonGuid(new Guid("54116d93-15e8-43ce-b34a-4b01e795be11")), "ValleyMainPlant", WorldArea.Valley, LocationType.Plant, new Vector2(-468.0f, -67.0f)),
+            new Location(new MoonGuid(new Guid("e8700000-f30c-4294-9a2d-51410549c601")), "WilhelmExp", WorldArea.Sorrow, LocationType.ExpLarge, new Vector2(-572.0f, 157.0f)),
+            new Location(new MoonGuid(new Guid("a550b330-e931-42cc-b00c-50ca36143ee7")), "ValleyRightSwimExp", WorldArea.Valley, LocationType.ExpMedium, new Vector2(-359.0f, -87.5f)),
+            new Location(new MoonGuid(new Guid("c3044298-0f52-44cc-a4e7-396db2822ef0")), "ValleyMainFACS", WorldArea.Valley, LocationType.AbilityCell, new Vector2(-415.5f, -80.0f)),
+            new Location(new MoonGuid(new Guid("467cdd0a-d736-4d51-af19-eee884ee066f")), "ValleyForlornApproachGrenade", WorldArea.Valley, LocationType.AbilityCell, new Vector2(-460.0f, -187.0f)),
+            new Location(new MoonGuid(new Guid("a306b326-2662-4035-9c97-2c4459f84a71")), "ValleyThreeBirdAbilityCell", WorldArea.Valley, LocationType.AbilityCell, new Vector2(-350.9f, -98.7f)),
+            new Location(new MoonGuid(new Guid("ed79b633-818d-4a00-844e-998fd2745b41")), "LowerValleyMapstone", WorldArea.Valley, LocationType.Mapstone, new Vector2(-561.0f, -89.0f)),
+            new Location(new MoonGuid(new Guid("09b3ac61-4972-4448-996b-93bc56222643")), "LowerValleyExp", WorldArea.Valley, LocationType.ExpMedium, new Vector2(-538.0f, -104.0f)),
+            new Location(new MoonGuid(new Guid("c068bb67-aed3-470c-90d2-c37fadd4f294")), "OutsideForlornTreeExp", WorldArea.Valley, LocationType.ExpMedium, new Vector2(-460.0f, -255.0f)),
+            new Location(new MoonGuid(new Guid("20d96007-fe1e-4469-b5fb-5c5f1f72e68f")), "OutsideForlornWaterExp", WorldArea.Valley, LocationType.ExpMedium, new Vector2(-514.5f, -277.3f)),
+            new Location(new MoonGuid(new Guid("ce0c05d0-dc62-4a92-adf9-85440516b089")), "OutsideForlornCliffExp", WorldArea.Valley, LocationType.ExpLarge, new Vector2(-538.7f, -234.7f)),
+            new Location(new MoonGuid(new Guid("3c59543f-9c36-43cc-9aab-69d859cae9ea")), "ValleyForlornApproachMapstone", WorldArea.Valley, LocationType.Mapstone, new Vector2(-443.0f, -152.0f)),
+            new Location(new MoonGuid(new Guid("a067bd11-efc4-4b4f-8d82-9b51ddf209ce")), "ForlornEntranceExp", WorldArea.Forlorn, LocationType.ExpLarge, new Vector2(-703.9f, -390.0f)),
+            new Location(new MoonGuid(new Guid("aec7c676-e2fe-4b4b-8af4-5c9674aac8b9")), "ForlornHiddenSpiderExp", WorldArea.Forlorn, LocationType.ExpMedium, new Vector2(-841.3f, -350.9f)),
+            new Location(new MoonGuid(new Guid("117b3edb-dc08-4488-b9a0-391ab9d57960")), "ForlornKeystone1", WorldArea.Forlorn, LocationType.Keystone, new Vector2(-858.0f, -353.0f)),
+            new Location(new MoonGuid(new Guid("77bcf456-5d29-4010-af33-bc913b951a93")), "ForlornKeystone2", WorldArea.Forlorn, LocationType.Keystone, new Vector2(-892.0f, -328.0f)),
+            new Location(new MoonGuid(new Guid("10eb191f-dac8-45bb-9c86-dc3ed1c77cc0")), "ForlornKeystone3", WorldArea.Forlorn, LocationType.Keystone, new Vector2(-888.0f, -251.0f)),
+            new Location(new MoonGuid(new Guid("5e483d15-dfef-408d-9545-d70633769e81")), "ForlornKeystone4", WorldArea.Forlorn, LocationType.Keystone, new Vector2(-869.0f, -255.0f)),
+            new Location(new MoonGuid(new Guid("3c0113b8-d5f3-4428-abfa-b00321a780bb")), "ForlornMap", WorldArea.Forlorn, LocationType.Map, new Vector2(-843.0f, -308.0f)),
+            new Location(new MoonGuid(new Guid("61b87fae-1434-409e-98c4-6c79598a9e73")), "ForlornPlant", WorldArea.Forlorn, LocationType.Plant, new Vector2(-815.0f, -266.0f)),
+            new Location(new MoonGuid(new Guid("da60ec6f-c4ba-493b-b4bd-4f7d8218a73a")), "RightForlornHealthCell", WorldArea.Forlorn, LocationType.HealthCell, new Vector2(-625.5f, -315.1f)),
+            new Location(new MoonGuid(new Guid("13f2bf4e-fa2c-46c8-bd24-8e3e4bb27e55")), "ForlornEscape", WorldArea.Forlorn, LocationType.Event, new Vector2(-732.0f, -236.0f)),
+            new Location(new MoonGuid(new Guid("92a35133-5de9-4bc5-83c6-9b359d9a0fbf")), "RightForlornPlant", WorldArea.Forlorn, LocationType.Plant, new Vector2(-607.0f, -314.0f)),
+            new Location(new MoonGuid(new Guid("e601dd92-c65c-4cf1-b442-accf961e6ab7")), "SorrowEntranceAbilityCell", WorldArea.Sorrow, LocationType.AbilityCell, new Vector2(-510.3f, 204.3f)),
+            new Location(new MoonGuid(new Guid("910dce6f-b896-42d9-b764-e5ef2ba9e471")), "SorrowMainShaftKeystone", WorldArea.Sorrow, LocationType.Keystone, new Vector2(-485.0f, 323.0f)),
+            new Location(new MoonGuid(new Guid("10919728-d585-443e-8e2d-86af53161f7c")), "SorrowSpikeKeystone", WorldArea.Sorrow, LocationType.Keystone, new Vector2(-503.0f, 274.0f)),
+            new Location(new MoonGuid(new Guid("6c13aced-1bd4-447e-a57d-c373a50142fb")), "SorrowHiddenKeystone", WorldArea.Sorrow, LocationType.Keystone, new Vector2(-514.0f, 303.0f)),
+            new Location(new MoonGuid(new Guid("ff0edbb1-882e-4221-a5e0-bfe3136611e3")), "SorrowLowerLeftKeystone", WorldArea.Sorrow, LocationType.Keystone, new Vector2(-596.0f, 229.0f)),
+            new Location(new MoonGuid(new Guid("937c8eed-a6fa-4bb9-92c3-46ba0d50adf5")), "SorrowMap", WorldArea.Sorrow, LocationType.Map, new Vector2(-451.0f, 284.0f)),
+            new Location(new MoonGuid(new Guid("917c444e-b83e-4bc9-b7e6-93e2d8ee695e")), "SorrowMapstone", WorldArea.Sorrow, LocationType.Mapstone, new Vector2(-435.0f, 322.0f)),
+            new Location(new MoonGuid(new Guid("12525396-13fd-4658-a7c3-8df57bac078e")), "SorrowHealthCell", WorldArea.Sorrow, LocationType.HealthCell, new Vector2(-609.0f, 299.0f)),
+            new Location(new MoonGuid(new Guid("eae7b2e1-351d-4b55-8b92-9fa04b307d36")), "LeftSorrowAbilityCell", WorldArea.Sorrow, LocationType.AbilityCell, new Vector2(-671.1f, 290.0f)),
+            new Location(new MoonGuid(new Guid("69616e29-9a5d-4382-89fb-6d17a8748780")), "LeftSorrowKeystone1", WorldArea.Sorrow, LocationType.Keystone, new Vector2(-608.0f, 329.0f)),
+            new Location(new MoonGuid(new Guid("2c561421-dc69-4148-a65e-4a264c5305c7")), "LeftSorrowKeystone2", WorldArea.Sorrow, LocationType.Keystone, new Vector2(-612.0f, 347.0f)),
+            new Location(new MoonGuid(new Guid("0eadcdde-8f34-488a-b6ef-b12581a2b27a")), "LeftSorrowKeystone3", WorldArea.Sorrow, LocationType.Keystone, new Vector2(-604.0f, 361.0f)),
+            new Location(new MoonGuid(new Guid("a296680b-4a68-4a3e-b664-0a95f6c9893c")), "LeftSorrowKeystone4", WorldArea.Sorrow, LocationType.Keystone, new Vector2(-613.1f, 371.7f)),
+            new Location(new MoonGuid(new Guid("e9ca9858-3abd-43b2-8f5e-233529859842")), "LeftSorrowEnergyCell", WorldArea.Sorrow, LocationType.EnergyCell, new Vector2(-627.1f, 394.0f)),
+            new Location(new MoonGuid(new Guid("8b7d005c-614e-42b3-9d38-9ee16313f668")), "LeftSorrowPlant", WorldArea.Sorrow, LocationType.Plant, new Vector2(-630.0f, 249.0f)),
+            new Location(new MoonGuid(new Guid("b31bf78c-695a-4594-aad6-822f9b42f767")), "LeftSorrowGrenade", WorldArea.Sorrow, LocationType.ExpLarge, new Vector2(-677.0f, 269.9f)),
+            new Location(new MoonGuid(new Guid("e8e62373-8d78-474c-bc2e-76244cfd5220")), "UpperSorrowRightKeystone", WorldArea.Sorrow, LocationType.Keystone, new Vector2(-456.0f, 419.0f)),
+            new Location(new MoonGuid(new Guid("de067109-811d-4138-9856-4836f217ece3")), "UpperSorrowFarRightKeystone", WorldArea.Sorrow, LocationType.Keystone, new Vector2(-414.0f, 429.0f)),
+            new Location(new MoonGuid(new Guid("46f35914-7b0b-4322-8c1d-3ffa1d9c8ab7")), "UpperSorrowLeftKeystone", WorldArea.Sorrow, LocationType.Keystone, new Vector2(-514.0f, 427.0f)),
+            new Location(new MoonGuid(new Guid("d5b98071-5721-4e15-b2a4-62fde346be0d")), "UpperSorrowSpikeExp", WorldArea.Sorrow, LocationType.ExpMedium, new Vector2(-545.0f, 409.5f)),
+            new Location(new MoonGuid(new Guid("8395174a-d06d-461b-ba37-b9dd97ee322b")), "UpperSorrowFarLeftKeystone", WorldArea.Sorrow, LocationType.Keystone, new Vector2(-592.0f, 445.0f)),
+            new Location(new MoonGuid(new Guid("24783b59-4196-4fcb-bd42-d1a925962e86")), "ChargeJumpSkillTree", WorldArea.Sorrow, LocationType.Skill, new Vector2(-696.0f, 408.0f)),
+            new Location(new MoonGuid(new Guid("ce467c66-3616-4596-b052-3aa36b9daeab")), "AboveChargeJumpAbilityCell", WorldArea.Sorrow, LocationType.AbilityCell, new Vector2(-646.9f, 473.1f)),
+            new Location(new MoonGuid(new Guid("50ffb37d-475f-48f3-911a-bb1c5ba6dd79")), "Sunstone", WorldArea.Sorrow, LocationType.Event, new Vector2(-560.0f, 600.0f)),
+            new Location(new MoonGuid(new Guid("f8927d97-73bb-405d-bc66-a97d29b7de94")), "SunstonePlant", WorldArea.Sorrow, LocationType.Plant, new Vector2(-478.0f, 586.0f)),
+            new Location(new MoonGuid(new Guid("2f9b8590-168f-4a66-9543-4fce8b1a1035")), "MistyEntranceStompExp", WorldArea.Misty, LocationType.ExpMedium, new Vector2(-678.1f, -30.0f)),
+            new Location(new MoonGuid(new Guid("b91ec03d-b110-4d53-960f-724dc406a7f7")), "MistyEntranceTreeExp", WorldArea.Misty, LocationType.ExpMedium, new Vector2(-822.3f, -9.7f)),
+            new Location(new MoonGuid(new Guid("47513f30-c883-46f0-9193-8f30c1d3b060")), "MistyFrogNookExp", WorldArea.Misty, LocationType.ExpMedium, new Vector2(-979.3f, 23.6f)),
+            new Location(new MoonGuid(new Guid("d7491440-a5d3-40f0-a937-7b2e4cc1a95e")), "MistyKeystone1", WorldArea.Misty, LocationType.Keystone, new Vector2(-1076.0f, 32.0f)),
+            new Location(new MoonGuid(new Guid("40675dbd-5f3c-4e1c-86ee-c7241c5fdd52")), "MistyMortarCorridorUpperExp", WorldArea.Misty, LocationType.ExpMedium, new Vector2(-1083.0f, 8.3f)),
+            new Location(new MoonGuid(new Guid("958dfa0f-6ab3-422e-b1e1-98a71eef37ba")), "MistyMortarCorridorHiddenExp", WorldArea.Misty, LocationType.ExpMedium, new Vector2(-1009.0f, -35.0f)),
+            new Location(new MoonGuid(new Guid("5e563952-174f-42be-ab22-17a901dd29e0")), "MistyPlant", WorldArea.Misty, LocationType.Plant, new Vector2(-1102.0f, -67.0f)),
+            new Location(new MoonGuid(new Guid("a273c819-a2c7-44c9-8798-a6510fc25e0d")), "ClimbSkillTree", WorldArea.Misty, LocationType.Skill, new Vector2(-1188.0f, -100.0f)),
+            new Location(new MoonGuid(new Guid("920137e5-c082-428b-93a1-bcb8f67a0748")), "MistyKeystone3", WorldArea.Misty, LocationType.Keystone, new Vector2(-912.0f, -36.0f)),
+            new Location(new MoonGuid(new Guid("43c5043b-4b30-4cc3-84e3-baedb5e5a378")), "MistyPostClimbSpikeCave", WorldArea.Misty, LocationType.ExpMedium, new Vector2(-837.7f, -123.5f)),
+            new Location(new MoonGuid(new Guid("8eae37fc-ca7a-4f9b-904b-47384ed8ec39")), "MistyPostClimbAboveSpikePit", WorldArea.Misty, LocationType.ExpLarge, new Vector2(-796.0f, -144.0f)),
+            new Location(new MoonGuid(new Guid("654eae78-1b9e-4554-85a3-10523617bcf5")), "MistyKeystone4", WorldArea.Misty, LocationType.Keystone, new Vector2(-768.0f, -144.0f)),
+            new Location(new MoonGuid(new Guid("817a54c5-92b6-47da-8891-59b51020b2c3")), "MistyGrenade", WorldArea.Misty, LocationType.ExpLarge, new Vector2(-671.9f, -39.4f)),
+            new Location(new MoonGuid(new Guid("62b3451f-85cd-423e-941c-8fbe4589ee55")), "MistyKeystone2", WorldArea.Misty, LocationType.Keystone, new Vector2(-1043.0f, -8.0f)),
+            new Location(new MoonGuid(new Guid("08b6537c-6090-4ff2-96ea-ee4123feb799")), "MistyAbilityCell", WorldArea.Misty, LocationType.AbilityCell, new Vector2(-1075.7f, -2.2f)),
+            new Location(new MoonGuid(new Guid("40872a5d-1d65-46c9-bd05-39b991ebce58")), "GumonSeal", WorldArea.Misty, LocationType.Event, new Vector2(-720.0f, -24.0f)),
+            new Location(new MoonGuid(new Guid("00000000-0000-0000-0000-100000000001")), "ProgressiveMap1", WorldArea.Void, LocationType.ProgressiveMap, new Vector2(0.0f, 24.0f)),
+            new Location(new MoonGuid(new Guid("00000000-0000-0000-0000-100000000002")), "ProgressiveMap2", WorldArea.Void, LocationType.ProgressiveMap, new Vector2(0.0f, 28.0f)),
+            new Location(new MoonGuid(new Guid("00000000-0000-0000-0000-100000000003")), "ProgressiveMap3", WorldArea.Void, LocationType.ProgressiveMap, new Vector2(0.0f, 32.0f)),
+            new Location(new MoonGuid(new Guid("00000000-0000-0000-0000-100000000004")), "ProgressiveMap4", WorldArea.Void, LocationType.ProgressiveMap, new Vector2(0.0f, 36.0f)),
+            new Location(new MoonGuid(new Guid("00000000-0000-0000-0000-100000000005")), "ProgressiveMap5", WorldArea.Void, LocationType.ProgressiveMap, new Vector2(0.0f, 40.0f)),
+            new Location(new MoonGuid(new Guid("00000000-0000-0000-0000-100000000006")), "ProgressiveMap6", WorldArea.Void, LocationType.ProgressiveMap, new Vector2(0.0f, 44.0f)),
+            new Location(new MoonGuid(new Guid("00000000-0000-0000-0000-100000000007")), "ProgressiveMap7", WorldArea.Void, LocationType.ProgressiveMap, new Vector2(0.0f, 48.0f)),
+            new Location(new MoonGuid(new Guid("00000000-0000-0000-0000-100000000008")), "ProgressiveMap8", WorldArea.Void, LocationType.ProgressiveMap, new Vector2(0.0f, 52.0f)),
+            new Location(new MoonGuid(new Guid("00000000-0000-0000-0000-100000000009")), "ProgressiveMap9", WorldArea.Void, LocationType.ProgressiveMap, new Vector2(0.0f, 56.0f))
         };
-
-
     }
 }

--- a/Core/RandomizerController.cs
+++ b/Core/RandomizerController.cs
@@ -142,12 +142,9 @@ namespace OriBFArchipelago.Core
 
         private void FixedUpdate()
         {
-            if (Keybinder.OnPressed(KeybindAction.OpenTeleport))
+            if (Keybinder.OnPressed(KeybindAction.OpenTeleport) && PlayerHasControl)
             {
-                if (PlayerHasControl)
-                {
-                    OpenTeleportMenu();
-                }
+                OpenTeleportMenu();
             }
 
             if (Keybinder.OnPressed(KeybindAction.ListStones))
@@ -158,6 +155,12 @@ namespace OriBFArchipelago.Core
             if (Keybinder.OnPressed(KeybindAction.GoalProgress))
             {
                 RandomizerManager.Connection.IsGoalComplete();
+            }
+
+            if (Keybinder.OnPressed(KeybindAction.Reconnect) && PlayerHasControl)
+            {
+                RandomizerManager.Receiver.OnReconnect();
+                RandomizerManager.Connection.Reconnect();
             }
 
             if (LocalGameState.TeleportNightberry && PlayerHasControl && Items.NightBerry != null)

--- a/Core/RandomizerOptions.cs
+++ b/Core/RandomizerOptions.cs
@@ -48,7 +48,7 @@ namespace OriBFArchipelago.Core
         public int WarmthFragmentsAvailable { get; }
         public int WarmthFragmentsRequired { get; }
         public int RelicCount { get; }
-        public string[] WorldTourAreas { get; }
+        public WorldArea[] WorldTourAreas { get; }
         public DifficultyOptions LogicDifficulty { get; }
         public KeyStoneOptions KeyStoneLogic { get; }
         public MapStoneOptions MapStoneLogic { get; }
@@ -61,7 +61,7 @@ namespace OriBFArchipelago.Core
                 WarmthFragmentsAvailable = apSlotData.TryGetValue("warmth_fragments_available", out object warmthFragmentsAvailable) ? Convert.ToInt32(warmthFragmentsAvailable) : 0;
                 WarmthFragmentsRequired = apSlotData.TryGetValue("warmth_fragments_required", out object warmthFragmentsRequired) ? Convert.ToInt32(warmthFragmentsRequired) : 0;
                 RelicCount = apSlotData.TryGetValue("relic_count", out object relicCount) ? Convert.ToInt32(relicCount) : 0;
-                WorldTourAreas = apSlotData.TryGetValue("world_tour_areas", out object worldTourAreas) ? JsonConvert.DeserializeObject<string[]>(worldTourAreas.ToString()) : [];
+                WorldTourAreas = apSlotData.TryGetValue("world_tour_areas", out object worldTourAreas) ? JsonConvert.DeserializeObject<WorldArea[]>(worldTourAreas.ToString()) : [];
                 LogicDifficulty = apSlotData.TryGetValue("logic_difficulty", out object difficultyOption) ? (DifficultyOptions) Enum.ToObject(typeof(DifficultyOptions), difficultyOption) : DifficultyOptions.Casual;
                 KeyStoneLogic = apSlotData.TryGetValue("keystone_logic", out object keystoneOption) ? (KeyStoneOptions) Enum.ToObject(typeof(KeyStoneOptions), keystoneOption) : KeyStoneOptions.Anywhere;
                 MapStoneLogic = apSlotData.TryGetValue("mapstone_logic", out object mapstoneOption) ? (MapStoneOptions) Enum.ToObject(typeof(MapStoneOptions), mapstoneOption) : MapStoneOptions.Anywhere;

--- a/Core/RandomizerReceiver.cs
+++ b/Core/RandomizerReceiver.cs
@@ -2,6 +2,7 @@
 using OriBFArchipelago.Extensions;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace OriBFArchipelago.Core
 {
@@ -27,7 +28,7 @@ namespace OriBFArchipelago.Core
         // compares against savedInventory to make sure items aren't duplicated
         private RandomizerInventory onLoadInventory;
 
-        // locally saves the locaiotns that have been checked in game
+        // locally saves the locations that have been checked in game
         private List<string> checkedLocations;
 
         // similar purpose to unsavedInventory
@@ -228,6 +229,15 @@ namespace OriBFArchipelago.Core
         }
 
         /**
+         * Returns a list of all locally checked locations
+         */
+        public IEnumerable<string> GetAllLocations()
+        {
+            
+            return checkedLocations.Concat(unsavedCheckedLocations);
+        }
+
+        /**
          * Called when the player dies
          */
         public void OnDeath()
@@ -261,6 +271,14 @@ namespace OriBFArchipelago.Core
             
             RandomizerIO.WriteSaveFile(saveSlot, savedInventory, checkedLocations);
             Resync();
+        }
+
+        /**
+         * Called when the player tries to reconnect to the archipelago server from within the game
+         */
+        public void OnReconnect()
+        {
+            onLoadInventory.Reset();
         }
 
         /**

--- a/Patches/DeathSavePatches.cs
+++ b/Patches/DeathSavePatches.cs
@@ -15,11 +15,7 @@ namespace OriBFArchipelago.Patches
             RandomizerManager.Receiver.OnDeath();
 
             // assume damage that is over 100 is meant to be an insta kill
-            if (RandomizerManager.Options.DeathLinkLogic == DeathLinkOptions.Full ||
-                RandomizerManager.Options.DeathLinkLogic == DeathLinkOptions.Partial && damage.Amount < 100)
-            {
-                RandomizerManager.Connection.SendDeathLink();
-            }
+            RandomizerManager.Connection.OnDeath(damage.Amount > 100);
         }
     }
 

--- a/Patches/MapStonePatch.cs
+++ b/Patches/MapStonePatch.cs
@@ -13,7 +13,7 @@ namespace OriBFArchipelago.Patches
     {
         private static void Grant(MapStone mapstone)
         {
-            RandomizerManager.Connection.CheckLocationByGameObject(mapstone.gameObject);
+            RandomizerManager.Connection.CheckLocation(mapstone.GetComponent<VisibleOnWorldMap>().MoonGuid);
         }
 
         private static int GetCurrentMapstonesCount() => RandomizerManager.Receiver.GetCurrentMapstonesCount();

--- a/Patches/PetrifiedPlantPatch.cs
+++ b/Patches/PetrifiedPlantPatch.cs
@@ -14,7 +14,7 @@ namespace OriBFArchipelago.Patches
         {
             if (__instance.NoHealthLeft && __instance.Entity is PetrifiedPlant)
             {
-                RandomizerManager.Connection.CheckLocationByGameObject(__instance.Entity.gameObject);
+                RandomizerManager.Connection.CheckLocation(__instance.Entity.MoonGuid);
             }
         }
     }

--- a/Patches/SeinPickupPatches.cs
+++ b/Patches/SeinPickupPatches.cs
@@ -16,7 +16,7 @@ namespace OriBFArchipelago.Patches
         static bool Prefix(SkillPointPickup skillPointPickup)
         {
             skillPointPickup.Collected();
-            RandomizerManager.Connection.CheckLocationByGameObject(skillPointPickup.gameObject);
+            RandomizerManager.Connection.CheckLocation(skillPointPickup.GetComponent<VisibleOnWorldMap>().MoonGuid);
             return false;
         }
     }
@@ -44,7 +44,7 @@ namespace OriBFArchipelago.Patches
         static bool Prefix(MaxEnergyContainerPickup energyContainerPickup)
         {
             energyContainerPickup.Collected();
-            RandomizerManager.Connection.CheckLocationByGameObject(energyContainerPickup.gameObject);
+            RandomizerManager.Connection.CheckLocation(energyContainerPickup.GetComponent<VisibleOnWorldMap>().MoonGuid);
             return false;
         }
     }
@@ -55,7 +55,7 @@ namespace OriBFArchipelago.Patches
         static bool Prefix(MaxHealthContainerPickup maxHealthContainerPickup)
         {
             maxHealthContainerPickup.Collected();
-            RandomizerManager.Connection.CheckLocationByGameObject(maxHealthContainerPickup.gameObject);
+            RandomizerManager.Connection.CheckLocation(maxHealthContainerPickup.GetComponent<VisibleOnWorldMap>().MoonGuid);
             return false;
         }
     }
@@ -66,7 +66,7 @@ namespace OriBFArchipelago.Patches
         static bool Prefix(KeystonePickup keystonePickup)
         {
             keystonePickup.Collected();
-            RandomizerManager.Connection.CheckLocationByGameObject(keystonePickup.gameObject);
+            RandomizerManager.Connection.CheckLocation(keystonePickup.GetComponent<VisibleOnWorldMap>().MoonGuid);
             return false;
         }
     }
@@ -164,7 +164,7 @@ namespace OriBFArchipelago.Patches
         static bool Prefix(MapStonePickup mapStonePickup)
         {
             mapStonePickup.Collected();
-            RandomizerManager.Connection.CheckLocationByGameObject(mapStonePickup.gameObject);
+            RandomizerManager.Connection.CheckLocation(mapStonePickup.GetComponent<VisibleOnWorldMap>().MoonGuid);
             return false;
         }
     }
@@ -227,7 +227,7 @@ namespace OriBFArchipelago.Patches
             {
                 // these are spirit light containers
                 expOrbPickup.Collected();
-                RandomizerManager.Connection.CheckLocationByGameObject(expOrbPickup.gameObject);
+                RandomizerManager.Connection.CheckLocation(expOrbPickup.GetComponent<VisibleOnWorldMap>().MoonGuid);
                 return false;
             }
             else

--- a/Patches/SkillPatches.cs
+++ b/Patches/SkillPatches.cs
@@ -12,7 +12,7 @@ namespace OriBFArchipelago.Patches
     {
         private static void Postfix(GetAbilityPedestal __instance)
         {
-            RandomizerManager.Connection.CheckLocation(__instance.Ability.ToString() + "SkillTree");
+            RandomizerManager.Connection.CheckLocation(__instance.MoonGuid);
         }
 
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
@@ -37,9 +37,9 @@ namespace OriBFArchipelago.Patches
         // This is called only when collecting sein or feather - no other skills
         private static bool Prefix(GetAbilityAction __instance)
         {
-            if (LocationLookup.GetLocationName(__instance.gameObject) == "GlideSkillFeather")
+            if (LocationLookup.Get(__instance.MoonGuid)?.Name == "GlideSkillFeather")
             {
-                RandomizerManager.Connection.CheckLocationByGameObject(__instance.gameObject);
+                RandomizerManager.Connection.CheckLocation(__instance.MoonGuid);
                 return false;
             }
             return true;


### PR DESCRIPTION
Rewrote the entire location lookup class. Now locations can be search by name or MoonGuid instead of position

Added datastorage tracking of map locations, relic areas, and player position

Locally checked locations are now re-sent to the server on reload, meaning locations can be checked while disconnected